### PR TITLE
Fix Tests failing with Lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -15,6 +15,7 @@ services:
       environment:
         DRUSH_OPTIONS_ROOT: '/app/web'
         DRUSH_OPTIONS_URI: 'http://localgov.lndo.site'
+        SIMPLETEST_DB: 'mysql://database:database@database/database'
   database:
     creds:
       user: database


### PR DESCRIPTION
Fix localgovdrupal/localgov#38

Adds the database to Lando environment variables.
Allows `lando phpunit` to run tests.
This will require lando rebuild to take effect.