### PR TITLE
Adds docker image for running chromedriver, set PHPUnit environment variable.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -16,6 +16,7 @@ services:
         DRUSH_OPTIONS_ROOT: '/app/web'
         DRUSH_OPTIONS_URI: 'http://localgov.lndo.site'
         SIMPLETEST_DB: 'mysql://database:database@database/database'
+        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", { "chromeOptions": { "w3c": false } }, "http://chromedriver:4444/wd/hub"]'
   database:
     creds:
       user: database
@@ -39,6 +40,18 @@ services:
     overrides:
       ports:
       - '3050:3050'
+  chromedriver:
+    type: compose
+    services:
+      image: robcherry/docker-chromedriver:latest
+      environment:
+        CHROMEDRIVER_WHITELISTED_IPS: ""
+        CHROMEDRIVER_URL_BASE: "/wd/hub"
+      security_opt:
+        - seccomp:unconfined
+      expose:
+        - '4444'
+      command: ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
 tooling:
   deprecated:
     service: appserver


### PR DESCRIPTION
Guess this could be done with the drupalci one as well, but I didn't stumble over the documentation for that. This image is the one that lando has lined up in their issues/guide.