### PR TITLE
PHPStan version compatibility issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "drupal/config_inspector": "^1.1",
         "drupal/core-dev": "^8.8",
         "mglaman/phpstan-drupal": "^0.12.3",
+        "phpstan/phpstan": "0.12.42",
         "phpstan/phpstan-deprecation-rules": "^0.12.2"
     },
     "conflict": {


### PR DESCRIPTION
The latest phpstan version 0.12.43 is throwing errors while analysing LocalGov
Drupal.  The error is about Drupal core files, so unlikely to be a LocalGov
Drupal issue.  The previous version of phpstan (0.12.42) works fine.  So we are
pinning phpstan to 0.12.42.

Relevant error message:
```
Reflection error: Drupal\Tests\PhpunitCompatibilityTrait not found.
💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
```

Issue: https://github.com/localgovdrupal/drupal-container/issues/5