### PR TITLE
phpcs incompatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "drupal/core-dev": "^8.8",
         "mglaman/phpstan-drupal": "^0.12.3",
         "phpstan/phpstan": "0.12.42",
-        "phpstan/phpstan-deprecation-rules": "^0.12.2"
+        "phpstan/phpstan-deprecation-rules": "^0.12.2",
+        "squizlabs/php_codesniffer": "3.5.6"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
squizlabs/php_codesniffer versions 3.5.7 and 3.5.8, the two latest ones, are
throwing PHP fatal errors.  So sticking with version 3.5.6 for now.

Sample error message:
```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function DrupalPractice\Sniffs\CodeAnalysis\ScopeInfo::__construct(), 0 passed in <snipped>/localgov-project/vendor/squizlabs/php_codesniffer/src/Ruleset.php on line 1209 and exactly 1 expected in <snipped>/localgov-project/vendor/drupal/coder/coder_sniffer/DrupalPractice/Sniffs/CodeAnalysis/VariableAnalysisSniff.php:49
...
```
Resolves #23