### PR TITLE
Test for PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
-        "bin-dir": "bin/"
+        "bin-dir": "bin/",
+        "platform": {
+            "php": "7.2"
+        }
     },
     "extra": {
         "enable-patching": true,


### PR DESCRIPTION
Github actions's Ubuntu latest VM image now uses PHP 8.  But we need PHP 7.2.  Trying to find out if composer's platform config can be a potential solution.