### PR TITLE
Prepare release 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/core-composer-scaffold": "^8.9",
         "drupal/core-project-message": "^8.9",
         "drupal/core-recommended": "^8.9",
-        "localgovdrupal/localgov": "^1.0@alpha"
+        "localgovdrupal/localgov": "^1.0"
     },
     "require-dev": {
         "brianium/paratest": "^4.0.0",


### PR DESCRIPTION
Only change fixing to version ^1.0 in place of ^1.0alpha. Then we tag 1.0.0 of the project itself.