### PR TITLE
Add environment variables for phpunit.

### DIFF
--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -19,7 +19,7 @@ services:
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", { "chromeOptions": { "w3c": false } }, "http://chromedriver:4444/wd/hub"]'
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
         BROWSERTEST_OUTPUT_BASE_URL: 'https://localgov.lndo.site'
-    buid:
+    build:
       - mkdir -p web/sites/simpletest/browser_output
   database:
     creds:

--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -17,6 +17,8 @@ services:
         DRUSH_OPTIONS_URI: 'https://localgov.lndo.site'
         SIMPLETEST_DB: 'mysql://database:database@database/database'
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", { "chromeOptions": { "w3c": false } }, "http://chromedriver:4444/wd/hub"]'
+        BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
+        BROWSERTEST_OUTPUT_BASE_URL: 'https://localgov.lndo.site'
   database:
     creds:
       user: database

--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -19,6 +19,8 @@ services:
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", { "chromeOptions": { "w3c": false } }, "http://chromedriver:4444/wd/hub"]'
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
         BROWSERTEST_OUTPUT_BASE_URL: 'https://localgov.lndo.site'
+    buid:
+      - mkdir -p web/sites/simpletest/browser_output
   database:
     creds:
       user: database


### PR DESCRIPTION
The environment variables do get the tests outputiing html, but only after creating the directory `web/sites/simpletest/browser_output`

@ekes @stephen-cox is there a way to create the directory for browser_output with composer at install? 