### PR TITLE
Added Solr to Lando with a script to fetch the latest Solr config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,8 @@
 # Ignore Lando overrides
 .lando.local.yml
 
+# Ignore Lando Solr config
+/.lando/solr
+
 # Ignore temp files
 /.phpunit.result.cache

--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -9,6 +9,8 @@ proxy:
     - mail.localgov.lndo.site
   adminer:
     - adminer.localgov.lndo.site
+  solr-sitewide:
+    - 'solr-sitewide.localgov.lndo.site:8983'
 services:
   appserver:
     overrides:
@@ -56,6 +58,11 @@ services:
       expose:
         - '4444'
       command: ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
+  solr-sitewide:
+    type: solr:8
+    core: sitewide
+    config:
+      dir: .lando/solr/localgov_sitewide_solr
 tooling:
   deprecated:
     service: appserver
@@ -93,3 +100,6 @@ tooling:
     service: node
   yarn:
     service: node
+  update-solr-config:
+    service: appserver
+    cmd: /app/.lando/update-solr-config.sh

--- a/.lando/update-solr-config.sh
+++ b/.lando/update-solr-config.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+##
+# Update Lando Solr config.
+##
+
+# List of Solr servers to fetch config for.
+export SERVERS=( localgov_sitewide_solr )
+
+for SERVER in "${SERVERS[@]}"; do
+  echo "Fetching Solr config for ${SERVER}."
+  mkdir -p ".lando/solr/${SERVER}"
+  drush search-api-solr:get-server-config ${SERVER} "/tmp/${SERVER}.zip"
+  unzip -qo "/tmp/${SERVER}.zip" -d ".lando/solr/${SERVER}"
+  rm "/tmp/${SERVER}.zip"
+done
+
+echo "
+For the new Solr config to be recognized you must restart Lando."

--- a/.lando/update-solr-config.sh
+++ b/.lando/update-solr-config.sh
@@ -4,16 +4,18 @@
 # Update Lando Solr config.
 ##
 
-# List of Solr servers to fetch config for.
-export SERVERS=( localgov_sitewide_solr )
-
-for SERVER in "${SERVERS[@]}"; do
+for SERVER in `drush search-api:server-list --field=ID | grep solr`; do
   echo "Fetching Solr config for ${SERVER}."
   mkdir -p ".lando/solr/${SERVER}"
   drush search-api-solr:get-server-config ${SERVER} "/tmp/${SERVER}.zip"
   unzip -qo "/tmp/${SERVER}.zip" -d ".lando/solr/${SERVER}"
   rm "/tmp/${SERVER}.zip"
+  UPDATED=true
 done
 
-echo "
+if [ "$UPDATED" = true ]; then
+  echo "
 For the new Solr config to be recognized you must restart Lando."
+else
+  echo "No Solr servers found."
+fi

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "drupal/core-composer-scaffold": "^9.1",
         "drupal/core-project-message": "^9.1",
         "drupal/core-recommended": "^9.1",
-        "localgovdrupal/localgov": "^2.0"
+        "localgovdrupal/localgov": "^2.0",
+        "localgovdrupal/localgov_search_solr": "^1.0@alpha"
     },
     "require-dev": {
         "brianium/paratest": "^6.0",


### PR DESCRIPTION
This PR adds Solr to Lando for the [localgov_search_solr](https://github.com/localgovdrupal/localgov_search_solr) module.

To test it you will need to `composer require localgovdrupal/localgov_search_solr` and enable it.

Fixes #86