### PR TITLE
Remove node from default lando configuration.

### DIFF
--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -39,13 +39,6 @@ services:
       image: dehy/adminer
       command: '/bin/s6-svscan /etc/services.d'
     portforward: true
-  node:
-    type: 'node:16'
-    globals:
-      gulp-cli: latest
-    overrides:
-      ports:
-      - '3050:3050'
   chromedriver:
     type: compose
     services:
@@ -92,14 +85,6 @@ tooling:
     description: Disable xdebug for apache.
     cmd: "rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && /etc/init.d/apache2 reload"
     user: root
-  gulp:
-    service: node
-  node:
-    service: node
-  npm:
-    service: node
-  yarn:
-    service: node
   update-solr-config:
     service: appserver
     cmd: /app/.lando/update-solr-config.sh


### PR DESCRIPTION
We don't use node in the theme or anywhere, so no point having it in the default lando file. 

Fixes #96 