### PR TITLE
Enable php-http/discovery plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "php-http/discovery": false
+            "php-http/discovery": true
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "php-http/discovery": false
         }
     },
     "extra": {


### PR DESCRIPTION
Breaking change in php-http/discovery prompts you to require a plugin. ~~If accepted, this project build gets stuck in an endless composer loop.~~ Endless loop is now fixed in php-http/discovery.

Discussion in discovery repo: https://github.com/php-http/discovery/issues/213