### PR TITLE
Require a stable version of Drupal core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "cweagans/composer-patches": "^1.6",
         "drupal/core-composer-scaffold": "^9.1",
         "drupal/core-project-message": "^9.1",
-        "drupal/core-recommended": "^9.1",
+        "drupal/core-recommended": "^9.1@stable",
         "localgovdrupal/localgov": "^2.0",
         "localgovdrupal/localgov_search_solr": "^1.0@alpha"
     },


### PR DESCRIPTION
This overrides the minimum stability for `drupal/core-recommended` to stable, to prevent locking to a dev release in cases where no stable version is an install candidate but an unstable one is (such as when there's a security release being prepared and a known-insecure conflict set like `roave/security-advisories` is being used).