### PR TITLE
refactor: lando quality improvements

### DIFF
--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -1,7 +1,6 @@
 name: localgov
 recipe: drupal10
 config:
-  xdebug: false
   webroot: web
   php: '8.1'
 proxy:
@@ -13,6 +12,11 @@ proxy:
     - 'solr-sitewide.localgov.lndo.site:8983'
 services:
   appserver:
+    xdebug: true
+    build_as_root:
+      # This disables Xdebug during build, but puts all dependencies in place
+      # ready for the tooling to enable Xdebug.
+      - rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && /etc/init.d/apache2 reload
     overrides:
       environment:
         DRUSH_OPTIONS_ROOT: '/app/web'
@@ -21,6 +25,9 @@ services:
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", { "chromeOptions": { "w3c": false } }, "http://chromedriver:4444/wd/hub"]'
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
         BROWSERTEST_OUTPUT_BASE_URL: 'https://localgov.lndo.site'
+        # Support debugging CLI with Xdebug.
+        PHP_IDE_CONFIG: "serverName=appserver"
+        XDEBUG_SESSION: "lando"
     build:
       - mkdir -p web/sites/simpletest/browser_output
   database:
@@ -40,7 +47,7 @@ services:
       command: '/bin/s6-svscan /etc/services.d'
     portforward: true
   node:
-    type: 'node:16'
+    type: 'node:18'
     globals:
       gulp-cli: latest
     overrides:
@@ -84,13 +91,13 @@ tooling:
     cmd: '/app/bin/phpunit --testdox'
   xdebug-on:
     service: appserver
-    description: Enable xdebug for apache.
-    cmd: "docker-php-ext-enable xdebug && /etc/init.d/apache2 reload"
+    description: Enable Xdebug for Apache.
+    cmd: rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker-php-ext-enable xdebug && /etc/init.d/apache2 reload && echo "Xdebug enabled"
     user: root
   xdebug-off:
     service: appserver
-    description: Disable xdebug for apache.
-    cmd: "rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && /etc/init.d/apache2 reload"
+    description: Disable Xdebug for Apache.
+    cmd: rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && /etc/init.d/apache2 reload && echo "Xdebug disabled"
     user: root
   gulp:
     service: node

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,12 +1,21 @@
 {
     "configurations": [
         {
-            "name": "Listen for Xdebug",
+            "name": "Listen for Xdebug (ddev)",
             "type": "php",
             "request": "launch",
             "port": 9003,
             "pathMappings": {
                 "/var/www/html": "${workspaceRoot}"
+              }
+        },
+        {
+            "name": "Listen for Xdebug (lando)",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/app": "${workspaceRoot}"
               }
         }
     ]

--- a/assets/composer/settings.lando.php
+++ b/assets/composer/settings.lando.php
@@ -131,14 +131,19 @@ $settings['rebuild_access'] = TRUE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
+ * Get Lando info
+ */
+$lando_info = json_decode(getenv('LANDO_INFO'), TRUE);
+
+/**
  * Lando database credentials.
  */
 $databases['default']['default'] = array (
-  'database' => 'database',
-  'username' => 'database',
-  'password' => 'database',
-  'host' => 'database',
-  'port' => '3306',
+  'database' => $lando_info['database']['creds']['database'],
+  'username' => $lando_info['database']['creds']['user'],
+  'password' => $lando_info['database']['creds']['password'],
+  'host' => $lando_info['database']['internal_connection']['host'],
+  'port' => $lando_info['database']['internal_connection']['port'],
   'driver' => 'mysql',
   'prefix' => '',
   'collation' => 'utf8mb4_general_ci',


### PR DESCRIPTION
I've added some small DX improvements for lando which make it more stable/predictable when using Xdebug;

- Xdebug tweaks to work out of the box all the time once `xdebug-on` is run (both cli and non-cli)
- Add lando to the vscode settings file
- Update node to version 18 to match Drupal 10.1 requirements
- Use the lando environment settings so we don't hardcode username/password/host, etc.. in settings files and it instead uses the values set in the `.lando.dist.yml` file