### PR TITLE
ci: fix phpstan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,9 @@ jobs:
           ref: php${{ matrix.php-version }}
 
       - name: Create LocalGov Drupal project
-        run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
+        run: |
+          composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
+          composer require drupal/group
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Create LocalGov Drupal project
         run: |
           composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
-          composer require drupal/group
+          composer --working-dir=./html require drupal/group
 
   phpcs:
     name: Coding standards checks

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,12 +1,13 @@
 parameters:
-	customRulesetUsed: true
-	reportUnmatchedIgnoredErrors: false
-	# Ignore phpstan-drupal extension's rules.
-	ignoreErrors:
-		- '#\Drupal calls should be avoided in classes, use dependency injection instead#'
-		- '#Plugin definitions cannot be altered.#'
-		- '#Missing cache backend declaration for performance.#'
-		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
+  level: 1
+  customRulesetUsed: true
+  reportUnmatchedIgnoredErrors: false
+  # Ignore phpstan-drupal extension's rules.
+  ignoreErrors:
+    - '#\Drupal calls should be avoided in classes, use dependency injection instead#'
+    - '#Plugin definitions cannot be altered.#'
+    - '#Missing cache backend declaration for performance.#'
+    - '#Plugin manager has cache backend specified but does not declare cache tags.#'
 #includes:
 #	- vendor/mglaman/phpstan-drupal/extension.neon
 #	- vendor/phpstan/phpstan-deprecation-rules/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,5 @@ parameters:
     - '#Plugin definitions cannot be altered.#'
     - '#Missing cache backend declaration for performance.#'
     - '#Plugin manager has cache backend specified but does not declare cache tags.#'
+    # new static() is a best practice in Drupal, so we cannot fix that.
+    - '#^Unsafe usage of new static#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,4 @@
 parameters:
-  level: 1
   customRulesetUsed: true
   reportUnmatchedIgnoredErrors: false
   # Ignore phpstan-drupal extension's rules.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 parameters:
+  # we don't set a level so that we check deprecations only, and
+  # not to highlight unknown classes which are from composer suggestions
   customRulesetUsed: true
   reportUnmatchedIgnoredErrors: false
   # Ignore phpstan-drupal extension's rules.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,3 @@ parameters:
     - '#Plugin definitions cannot be altered.#'
     - '#Missing cache backend declaration for performance.#'
     - '#Plugin manager has cache backend specified but does not declare cache tags.#'
-#includes:
-#	- vendor/mglaman/phpstan-drupal/extension.neon
-#	- vendor/phpstan/phpstan-deprecation-rules/rules.neon


### PR DESCRIPTION
While digging into PHP 8.2 issues that need fixing, I thought it was strange that PHPStan reported nothing, so it appears that it is missing the `level` parameter in the config which then causes it to not report PHP 8.2 related issues.

```
Access to an undefined property in PHPStan is basically the Dynamic properties deprecated in PHP 8.2
```
See: https://phpstan.org/blog/phpstan-is-ready-for-php-8-2

I've added this as level 1 to match [Drupal core](https://git.drupalcode.org/project/drupal/-/blob/10.1.x/core/phpstan.neon.dist?ref_type=heads) and now we can see PHP 8.2 issues picked up in the phpstan checks before unit tests and be more aligned with Drupal core on check level.

[Drupal check uses level 2](https://mglaman.dev/blog/drupal-check-140-enforcing-phpstan-level-2) but let's mirror core for now.

It would be good to get some thoughts on bumping to level 2, I think that we can leave for now but might be worth looking at in future.

Once this runs on the action, I should be able to cross-reference with what has been fixed more easily