### PR TITLE
ci: fail action on composer patch failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
   build:
     name: Install LocalGov Drupal
     runs-on: ubuntu-latest
+    env:
+      COMPOSER_EXIT_ON_PATCH_FAILURE: '1'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
More info here https://github.com/localgovdrupal/github_workflow_manager/issues/9 but this will make the action fail if any patches fail to apply, which should give better visibility on any patches that need fixing.

This is for GitHub action only so will not affect users.