### PR TITLE
CI: Grab suggested dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
 
       - name: Obtain suggested dependencies
-        run: composer --working-dir=./html/ suggests --list | xargs composer --working-dir=./html require
+        run: composer --working-dir=./html/ suggests --all --list | xargs composer --working-dir=./html require
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
 
       - name: Obtain all dev dependencies
-        run:  jq '.packages[] | select(.name | startswith("localgovdrupal/")) | ."require-dev" | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/composer.lock | xargs composer --working-dir=./html require --dev --no-interaction --no-plugins
+        run:  jq --raw-output '.packages[] | select(.name | startswith("localgovdrupal/")) | ."require-dev" | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/composer.lock | sort | uniq | xargs composer --working-dir=./html require --dev --no-interaction --no-plugins
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
 
       - name: Obtain all dev dependencies
-        run:  jq '.packages[]."require-dev" | keys? | flatten[]' ./html/composer.lock | xargs composer --working-dir=./html require --dev --no-interaction --no-plugins --with-all-dependencies
+        run:  jq '.packages[] | select(.name | startswith("localgovdrupal/")) | ."require-dev" | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/composer.lock | xargs composer --working-dir=./html require --dev --no-interaction --no-plugins
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
 
       - name: Obtain suggested dependencies
-        run: composer --working-dir=./html/ suggests --all --list | xargs composer --working-dir=./html require
+        run: composer --working-dir=./html/ suggests --all --list | grep -v '^ext-' | xargs composer --working-dir=./html require
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
 
       - name: Obtain all dev dependencies
-        run:  jq '.packages[]."require-dev" | keys? | flatten[]' ./html/composer.lock | xargs composer --working-dir=./html require --dev --no-interaction --no-plugins
+        run:  jq '.packages[]."require-dev" | keys? | flatten[]' ./html/composer.lock | xargs composer --working-dir=./html require --dev --no-interaction --no-plugins --with-all-dependencies
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Create LocalGov Drupal project
         run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
 
-      - name: Obtain suggested dependencies
-        run: composer --working-dir=./html/ suggests --all --list | grep -v '^ext-' | xargs composer --working-dir=./html require
+      - name: Obtain all dev dependencies
+        run:  jq '.packages[]."require-dev" | keys? | flatten[]' ./html/composer.lock | xargs composer --working-dir=./html require --dev --no-interaction --no-plugins
 
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,9 +79,10 @@ jobs:
           ref: php${{ matrix.php-version }}
 
       - name: Create LocalGov Drupal project
-        run: |
-          composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
-          composer --working-dir=./html require drupal/group
+        run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
+
+      - name: Obtain suggested dependencies
+        run: composer --working-dir=./html/ suggests --list | xargs composer --working-dir=./html require
 
   phpcs:
     name: Coding standards checks


### PR DESCRIPTION
Replacing explicit instruction to grab drupal/group with a more generic one that fetches all suggested dependencies from all dependencies.