### PR TITLE
CI: Install dev dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,9 +79,10 @@ jobs:
           ref: php${{ matrix.php-version }}
 
       - name: Create LocalGov Drupal project
-        run: |
-          composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
-          composer --working-dir=./html require drupal/group
+        run: composer create-project --stability dev localgovdrupal/localgov-project:${COMPOSER_REF} ./html
+
+      - name: Obtain all dev dependencies for LocalGov Drupal
+        run: jq --raw-output '.packages[] | select(.name | startswith("localgovdrupal/")) | ."require-dev" | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/composer.lock | sort | uniq | xargs composer --working-dir=./html require --dev --no-interaction
 
   phpcs:
     name: Coding standards checks


### PR DESCRIPTION
Adds all dev dependency packages belonging to various LocalGov Drupal packages.  Dev dependencies are sourced from the composer.lock file.

[Test failures](https://github.com/localgovdrupal/localgov_project/pull/138/checks) for this branch are originating from the [3.x branch](https://github.com/localgovdrupal/localgov_project/actions/runs/6609857216/job/17950755717).