### PR TITLE
Change PHPcs to phpcsstandards/php_codesniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "drupal/coder": "^8.3",
         "drupal/core-dev": "^10.0",
         "mglaman/phpstan-drupal": "^1.0",
+        "phpcsstandards/php_codesniffer": "^3.7",
         "phpspec/prophecy-phpunit": "^2",
         "phpstan/phpstan": "^1.0",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "squizlabs/php_codesniffer": "^3.6"
+        "phpstan/phpstan-deprecation-rules": "^1.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
Fix #145 

Just updates this in project, expect other dependencies to still use the old one?