### PR TITLE
chore: add php 8.3 support to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         php-version:
           - '8.1'
           - '8.2'
+          - '8.3'
 
     steps:
 
@@ -99,6 +100,7 @@ jobs:
         php-version:
           - '8.1'
           - '8.2'
+          - '8.3'
 
     steps:
 
@@ -135,6 +137,7 @@ jobs:
         php-version:
           - '8.1'
           - '8.2'
+          - '8.3'
 
     steps:
 
@@ -170,6 +173,7 @@ jobs:
         php-version:
           - '8.1'
           - '8.2'
+          - '8.3'
 
     steps:
 


### PR DESCRIPTION
Adds PHP 8.3 to the testing matrix, this requires a docker image creating in https://github.com/localgovdrupal/drupal-container/issues/32 first.

I'll create a follow-up PR around the end of October to drop PHP 8.1 testing once it hits end of life.