### PR TITLE
Minor DX quality of life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@
 .ddev/homeadditions/
 .ddev/providers/
 .ddev/xhprof/
+
+# Ignore macOS DS_Store files
+.DS_Store
+**/.DS_Store

--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -12,6 +12,8 @@ proxy:
     - 'solr-sitewide.localgov.lndo.site:8983'
 services:
   appserver:
+    scanner:
+      retry: 5
     xdebug: true
     build_as_root:
       # This disables Xdebug during build, but puts all dependencies in place

--- a/assets/composer/settings.lando.php
+++ b/assets/composer/settings.lando.php
@@ -33,7 +33,7 @@
  * @see https://wiki.php.net/rfc/expectations
  */
 assert_options(ASSERT_ACTIVE, TRUE);
-\Drupal\Component\Assertion\Handle::register();
+assert_options(ASSERT_EXCEPTION, TRUE);
 
 /**
  * Enable local development services.
@@ -147,7 +147,7 @@ $databases['default']['default'] = array (
   'driver' => 'mysql',
   'prefix' => '',
   'collation' => 'utf8mb4_general_ci',
-);
+  );
 
 /**
  * Error reporting.

--- a/assets/composer/settings.lando.php
+++ b/assets/composer/settings.lando.php
@@ -147,7 +147,7 @@ $databases['default']['default'] = array (
   'driver' => 'mysql',
   'prefix' => '',
   'collation' => 'utf8mb4_general_ci',
-  );
+);
 
 /**
  * Error reporting.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,10 +3,12 @@
   <description>PHP CodeSniffer configuration for LocalGovDrupal.</description>
 
   <arg name="extensions" value="inc,install,module,php,profile,test,theme,yml"/>
-  <config name="drupal_core_version" value="9"/>
+  <config name="drupal_core_version" value="10"/>
 
   <file>web/modules/contrib/</file>
   <file>web/profiles/contrib/localgov/</file>
+  <file>web/themes/contrib/localgov_base/</file>
+  <file>web/themes/contrib/localgov_scarfolk/</file>
   <!-- Exclude 3rd party code -->
   <exclude-pattern>web\/modules\/contrib\/(?!localgov_.*)</exclude-pattern>
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,10 +7,12 @@
 
   <file>web/modules/contrib/</file>
   <file>web/profiles/contrib/localgov/</file>
-  <file>web/themes/contrib/localgov_base/</file>
-  <file>web/themes/contrib/localgov_scarfolk/</file>
+  <file>web/themes/contrib/</file>
+
   <!-- Exclude 3rd party code -->
   <exclude-pattern>web\/modules\/contrib\/(?!localgov_.*)</exclude-pattern>
+  <exclude-pattern>web\/themes\/contrib\/(?!localgov_.*)</exclude-pattern>
+
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
   <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
 


### PR DESCRIPTION
Some minor changes that will hopefully improve other developers' experience when working locally.

1. Ignore macOS files in .gitignore
2. Change the Lando scanner to only check if the service is up 5 times, rather than the default 25
3. Fix deprecation in the settings file when running Lando
4. Add base themes to phpcs checks