### PR TITLE
Set environment variable SYMFONY_DEPRECATIONS_HELPER for phpunit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,8 @@
      external DDev URL so you can follow the links directly.
     -->
     <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <!-- Disable the deprecations helper for more readable test output. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
   </php>
 
   <testsuites>


### PR DESCRIPTION
Set environment variable SYMFONY_DEPRECATIONS_HELPER for phpunit to disabled to suppress deprecation notices in phpunit output.