### PR TITLE
ci: use drupalci webdriver image

### DIFF
--- a/.ddev/config.selenium-standalone-chrome.yaml
+++ b/.ddev/config.selenium-standalone-chrome.yaml
@@ -8,8 +8,7 @@ web_environment:
   # Use disable-dev-shm-usage instead of setting shm_usage
   # https://developers.google.com/web/tools/puppeteer/troubleshooting#tips
   # The format of chromeOptions is defined at https://chromedriver.chromium.org/capabilities
-  - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"chromeOptions\":{\"w3c\":false,\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
-  # Nightwatch
+  - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"w3c\":false,\"goog:chromeOptions\":{\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]  # Nightwatch
   - DRUPAL_TEST_BASE_URL=http://web
   - DRUPAL_TEST_DB_URL=mysql://db:db@db/db
   - DRUPAL_TEST_WEBDRIVER_HOSTNAME=selenium-chrome
@@ -22,4 +21,4 @@ web_environment:
   - DRUPAL_NIGHTWATCH_OUTPUT=reports/nightwatch
   # DTT
   - DTT_BASE_URL=http://web
-  - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"chromeOptions\":{\"w3c\":false,\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
+  - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"w3c\":false,\"goog:chromeOptions\":{\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]

--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -1,9 +1,8 @@
 # This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
 #
-version: '3.6'
 services:
   selenium-chrome:
-    image: seleniarm/standalone-chromium:4.1.4-20220429
+    image: drupalci/webdriver-chromedriver:production
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed

--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -23,11 +23,11 @@ services:
       environment:
         DRUSH_OPTIONS_ROOT: '/app/web'
         DRUSH_OPTIONS_URI: 'https://localgov.lndo.site'
-        SIMPLETEST_BASE_URL: 'https://localgov.lndo.site'
+        SIMPLETEST_BASE_URL: 'http://localgov.lndo.site'
         SIMPLETEST_DB: 'mysql://database:database@database/database'
-        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless","--no-sandbox"]}}, "http://chromedriver:9515"]'
+        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName": "chrome", "goog:chromeOptions": {"args": ["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chromedriver:9515"]'
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
-        BROWSERTEST_OUTPUT_BASE_URL: 'https://localgov.lndo.site'
+        BROWSERTEST_OUTPUT_BASE_URL: 'http://localgov.lndo.site'
         # Support debugging CLI with Xdebug.
         PHP_IDE_CONFIG: "serverName=appserver"
         XDEBUG_SESSION: "lando"

--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -23,8 +23,9 @@ services:
       environment:
         DRUSH_OPTIONS_ROOT: '/app/web'
         DRUSH_OPTIONS_URI: 'https://localgov.lndo.site'
+        SIMPLETEST_BASE_URL: 'https://localgov.lndo.site'
         SIMPLETEST_DB: 'mysql://database:database@database/database'
-        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", { "chromeOptions": { "w3c": false } }, "http://chromedriver:4444/wd/hub"]'
+        MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless","--no-sandbox"]}}, "http://chromedriver:9515"]'
         BROWSERTEST_OUTPUT_DIRECTORY: '/app/web/sites/simpletest/browser_output'
         BROWSERTEST_OUTPUT_BASE_URL: 'https://localgov.lndo.site'
         # Support debugging CLI with Xdebug.
@@ -57,16 +58,14 @@ services:
       - '3050:3050'
   chromedriver:
     type: compose
+    scanner: false
     services:
-      image: robcherry/docker-chromedriver:latest
-      environment:
-        CHROMEDRIVER_WHITELISTED_IPS: ""
-        CHROMEDRIVER_URL_BASE: "/wd/hub"
+      image: drupalci/webdriver-chromedriver:production
+      ports:
+        - "9515:9515"
       security_opt:
         - seccomp:unconfined
-      expose:
-        - '4444'
-      command: ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
+      command: chromedriver --verbose --allowed-ips= --allowed-origins=*
   solr-sitewide:
     type: solr:8
     core: sitewide


### PR DESCRIPTION
- Change the chrome webdriver image to align with the DrupalCI image (https://www.drupal.org/docs/develop/automated-testing/phpunit-in-drupal/running-phpunit-javascript-tests#docker-compose)
- Update the `MINK_DRIVER_ARGS_WEBDRIVER` to match DrupalCI
- Uses the same image as our workflow drupal-container