### PR TITLE
Chore: Removes the version key from docker-compose file.

### DIFF
--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -1,6 +1,5 @@
 # This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
 #
-version: '3.6'
 services:
   selenium-chrome:
     image: seleniarm/standalone-chromium:4.1.4-20220429


### PR DESCRIPTION
As per: https://github.com/ddev/ddev-selenium-standalone-chrome/pull/39 .