### PR TITLE
fix: docker-compose error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,7 +192,7 @@ jobs:
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Start Docker environment
-        run: docker-compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose.yml up -d
 
       - name: Run PHPUnit tests
         run: |


### PR DESCRIPTION
Fix `docker-compose` not found error on workflow (https://github.com/localgovdrupal/localgov_project/actions/runs/10217568905/job/28271799901)

See https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/