### PR TITLE
ci: add quality gate check for disallowed calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.5",
+        "spaze/phpstan-disallowed-calls": "^3.4",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "conflict": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,9 @@
 includes:
   - phpstan-baseline.neon
   - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+  - vendor/spaze/phpstan-disallowed-calls/disallowed-dangerous-calls.neon
+  - vendor/spaze/phpstan-disallowed-calls/disallowed-execution-calls.neon
+  - vendor/spaze/phpstan-disallowed-calls/disallowed-insecure-calls.neon
 
 parameters:
   level: 1


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This PR adds an extra quality gate check to the static analysis check to make sure there are no disallowed/dangerous/insecure calls in the codebase, such as:

- `var_dump()`
- `print_r()`
- `phpinfo()`
- `exec()`, `shell_exec()`, etc...

This will report that `sha1()` and `uniqid()` are forbidden in `localgov_alert_banner`, however we can update to ignore this error as the context that those functions are used is only for generating a token for the cookie when closing an alert banner.


## How to test

Run `lando sca`
