### PR TITLE
chore: use mariadb for lando

### DIFF
--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -3,6 +3,7 @@ recipe: drupal10
 config:
   webroot: web
   php: '8.1'
+  database: mariadb:10.6
 proxy:
   mailhog:
     - mail.localgov.lndo.site


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Changes the lando config to mariadb to match ddev (Fixes #99)


## Have we considered potential risks?

This is a destructive local change to the database and you'll lose the data on a rebuild if using lando.