### PR TITLE
fix: ignore content moderation and workspaces patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,11 +71,16 @@
             }
         },
         "patches-ignore": {
+            "localgovdrupal/localgov": {
+                "drupal/core": {
+                    "Content moderation and Workspaces https://www.drupal.org/project/drupal/issues/3179199#comment-15711680" : "https://www.drupal.org/files/issues/2024-08-11/3179199-3132022-content-moderation-workspaces-query.patch"
+                }
+            },
             "localgovdrupal/localgov_services": {
                 "drupal/core": {
                     "node_access filters out accessible nodes when node is left joined (1349080)" : "https://git.drupalcode.org/project/drupal/-/commit/c271adb.diff"
                 }
-            }    
+            }
         },
         "installer-paths": {
             "web/core": ["type:drupal-core"],


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Ignores the patch for content moderation and workspaces as this was fixed in 10.3, but not <10.3