### PR TITLE
feat: return types are required in all new methods and functions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1531,6 +1531,11 @@ parameters:
 			path: web/modules/contrib/localgov_guides/src/Plugin/Block/GuidesPrevNextBlock.php
 
 		-
+			message: "#^Variable \\$overview might not be defined\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_guides/src/Plugin/PreviewLinkAutopopulate/Guides.php
+
+		-
 			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\ContentsBlockTest\\:\\:testContentListBlock\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_guides/tests/src/Functional/ContentsBlockTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,572 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Function localgov_alert_banner_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.install
+
+		-
+			message: "#^Function localgov_alert_banner_update_10002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.install
+
+		-
+			message: "#^Function localgov_alert_banner_update_8801\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.install
+
+		-
+			message: "#^Function localgov_alert_banner_update_8901\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.install
+
+		-
+			message: "#^Function localgov_alert_banner_update_9001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.install
+
+		-
+			message: "#^Function localgov_alert_banner_update_9002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.install
+
+		-
+			message: "#^Function localgov_alert_banner_configure_scheduled_transitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function localgov_alert_banner_gin_content_form_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function localgov_alert_banner_help\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function localgov_alert_banner_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function localgov_alert_banner_preprocess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function localgov_alert_banner_preprocess_field\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function localgov_alert_banner_set_default_permissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function localgov_alert_banner_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function localgov_alert_banner_theme_suggestions_localgov_alert_banner\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.module
+
+		-
+			message: "#^Function template_preprocess_localgov_alert_banner\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/localgov_alert_banner.page.inc
+
+		-
+			message: "#^Function localgov_alert_banner_full_page_update_9001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.install
+
+		-
+			message: "#^Function localgov_alert_banner_full_page_preprocess_localgov_alert_banner__localgov_full_page\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.module
+
+		-
+			message: "#^Function localgov_alert_banner_full_page_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Access\\\\AlertBannerEntityPageAccess\\:\\:access\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Access/AlertBannerEntityPageAccess.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\AlertBannerEntityPermissions\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/AlertBannerEntityPermissions.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\AlertBannerEntityStorage\\:\\:clearRevisionsLanguage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/AlertBannerEntityStorage.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\AlertBannerEntityStorageInterface\\:\\:clearRevisionsLanguage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/AlertBannerEntityStorageInterface.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Controller\\\\AlertBannerEntityController\\:\\:getStatusFormTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Controller/AlertBannerEntityController.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Entity\\\\AlertBannerEntity\\:\\:getToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Entity/AlertBannerEntity.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Entity\\\\AlertBannerEntity\\:\\:postSave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Entity/AlertBannerEntity.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Entity\\\\AlertBannerEntity\\:\\:preCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Entity/AlertBannerEntity.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Entity\\\\AlertBannerEntity\\:\\:preSave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Entity/AlertBannerEntity.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Entity\\\\AlertBannerEntity\\:\\:setToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Entity/AlertBannerEntity.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Entity\\\\AlertBannerEntityType\\:\\:postSave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Entity/AlertBannerEntityType.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityForm\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityRevisionDeleteForm\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityRevisionDeleteForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityRevisionDeleteForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityRevisionDeleteForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityRevisionRevertForm\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityRevisionRevertForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityRevisionRevertForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityRevisionRevertForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityRevisionRevertTranslationForm\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityRevisionRevertTranslationForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntitySettingsForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntitySettingsForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityStatusForm\\:\\:getStatusChangedMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityStatusForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityStatusForm\\:\\:logStatusChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityStatusForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityStatusForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityStatusForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityTypeDeleteForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityTypeDeleteForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Form\\\\AlertBannerEntityTypeForm\\:\\:form\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityTypeForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Plugin\\\\Block\\\\AlertBannerBlock\\:\\:blockSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Plugin/Block/AlertBannerBlock.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Plugin\\\\views\\\\field\\\\StatusPageLink\\:\\:buildOptionsForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Plugin/views/field/StatusPageLink.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_alert_banner\\\\Routing\\\\AlertBannerRouteSubscriber\\:\\:alterRoutes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/src/Routing/AlertBannerRouteSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AdminViewTest\\:\\:testLoadAdminView\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AdminViewTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AlertBannerBlockTest\\:\\:testAlertBannerDisplays\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AlertBannerBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AlertBannerBlockTest\\:\\:testAlertBannerTypeDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AlertBannerBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AlertBannerBlockTest\\:\\:testAlertDisplayTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AlertBannerBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AlertBannerBlockTest\\:\\:testAlertRemoveHideLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AlertBannerBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AlertBannerBlockTest\\:\\:testNonLiveAlertBannerDoesNotDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AlertBannerBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AlertBannerBlockTest\\:\\:updateBlockSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AlertBannerBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AlertConfirmationTest\\:\\:testAlertConfirmation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AlertConfirmationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\AlertConfirmationTest\\:\\:testSaveAlertRedirect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/AlertConfirmationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\PermissionsTest\\:\\:testAlertBannerUserAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/PermissionsTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\ViewsStatusLinkTest\\:\\:testEntityLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/ViewsStatusLinkTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Functional\\\\VisibilityTest\\:\\:testAlertBannerVisibility\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Functional/VisibilityTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\FunctionalJavascript\\\\AlertBannerHideTest\\:\\:testAlertBannerHide\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Kernel\\\\AlertBannerBlockOrderTest\\:\\:testAlertBannerBlockOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Kernel/AlertBannerBlockOrderTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Kernel\\\\AlertBannerBlockOrderTest\\:\\:testAlertBannerBlockOrderWithoutTypeOfAlert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Kernel/AlertBannerBlockOrderTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Kernel\\\\SchedulingInstallTest\\:\\:testEnableLocalGovAlertBanner\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Kernel/SchedulingInstallTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Kernel\\\\SchedulingInstallTest\\:\\:testEnableScheduledTransitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Kernel/SchedulingInstallTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_alert_banner\\\\Kernel\\\\SchedulingTest\\:\\:testAlertBannerScheduling\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_alert_banner/tests/src/Kernel/SchedulingTest.php
+
+		-
+			message: "#^Function localgov_core_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/localgov_core.install
+
+		-
+			message: "#^Function localgov_core_update_8002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/localgov_core.install
+
+		-
+			message: "#^Function localgov_core_update_8003\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/localgov_core.install
+
+		-
+			message: "#^Function localgov_core_update_8004\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/localgov_core.install
+
+		-
+			message: "#^Function localgov_core_template_preprocess_default_variables_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/localgov_core.module
+
+		-
+			message: "#^Function localgov_core_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/localgov_core.module
+
+		-
+			message: "#^Function localgov_admin_role_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_admin_role/localgov_admin_role.install
+
+		-
+			message: "#^Function localgov_admin_theme_improvements_form_revision_overview_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_admin_theme_improvements/localgov_admin_theme_improvements.module
+
+		-
+			message: "#^Function localgov_admin_theme_improvements_layout_paragraph_element_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_admin_theme_improvements/localgov_admin_theme_improvements.module
+
+		-
+			message: "#^Function localgov_admin_theme_improvements_menu_local_tasks_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_admin_theme_improvements/localgov_admin_theme_improvements.module
+
+		-
+			message: "#^Function localgov_media_update_10001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_media/localgov_media.install
+
+		-
+			message: "#^Function localgov_media_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_media/localgov_media.module
+
+		-
+			message: "#^Function localgov_media_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_media/localgov_media.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_media\\\\Functional\\\\MediaSetupTest\\:\\:testImageCroppersInImageEditForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_media/tests/src/Functional/MediaSetupTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_media\\\\Functional\\\\MediaSetupTest\\:\\:testMediaBundles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_media/tests/src/Functional/MediaSetupTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_media\\\\Functional\\\\StandardProfileTest\\:\\:testEnablingLocalGovMedia\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_media/tests/src/Functional/StandardProfileTest.php
+
+		-
+			message: "#^Function localgov_roles_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_roles/localgov_roles.install
+
+		-
+			message: "#^Function localgov_roles_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_roles/localgov_roles.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_roles\\\\RolesHelper\\:\\:assignModuleRoles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_roles/src/RolesHelper.php
+
+		-
+			message: "#^Function localgov_roles_test_one_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_roles/tests/modules/localgov_roles_test_one/localgov_roles_test_one.module
+
+		-
+			message: "#^Function localgov_roles_test_two_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_roles/tests/modules/localgov_roles_test_two/localgov_roles_test_two.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_roles\\\\Kernel\\\\ModuleRolesTest\\:\\:testEnablingModulesImplementing\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_roles/tests/src/Kernel/ModuleRolesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_roles\\\\Kernel\\\\ModuleRolesTest\\:\\:testEnablingRolesModule\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/modules/localgov_roles/tests/src/Kernel/ModuleRolesTest.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_core\\\\Event\\\\PageHeaderDisplayEvent\\:\\:setCacheTags\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/src/Event/PageHeaderDisplayEvent.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_core\\\\Event\\\\PageHeaderDisplayEvent\\:\\:setLede\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/src/Event/PageHeaderDisplayEvent.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_core\\\\Event\\\\PageHeaderDisplayEvent\\:\\:setSubTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/src/Event/PageHeaderDisplayEvent.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_core\\\\Event\\\\PageHeaderDisplayEvent\\:\\:setTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/src/Event/PageHeaderDisplayEvent.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_core\\\\Event\\\\PageHeaderDisplayEvent\\:\\:setVisibility\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/src/Event/PageHeaderDisplayEvent.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_core\\\\FieldRenameHelper\\:\\:renameField\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/src/FieldRenameHelper.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_core\\\\Plugin\\\\Field\\\\FieldWidget\\\\LabelsWidget\\:\\:formMultipleElements\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/src/Plugin/Field/FieldWidget/LabelsWidget.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_core_page_header_event_test\\\\EventSubscriber\\\\PageHeaderSubscriber\\:\\:setPageHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/tests/localgov_core_page_header_event_test/src/EventSubscriber/PageHeaderSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_core\\\\Functional\\\\DefaultBlockTest\\:\\:testBlockDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/tests/src/Functional/DefaultBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_core\\\\Functional\\\\OnOffSwitchTest\\:\\:onOffProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/tests/src/Functional/OnOffSwitchTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_core\\\\Functional\\\\OnOffSwitchTest\\:\\:testOnOffSwitch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/tests/src/Functional/OnOffSwitchTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_core\\\\Functional\\\\PageHeaderBlockTest\\:\\:testPageHeaderBlockDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/tests/src/Functional/PageHeaderBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_core\\\\Functional\\\\PageHeaderBlockTest\\:\\:testPageHeaderDisplayEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/tests/src/Functional/PageHeaderBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_core\\\\Kernel\\\\FieldRenameHelperTest\\:\\:testRenameField\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/tests/src/Kernel/FieldRenameHelperTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_core\\\\Kernel\\\\FieldRenameHelperTest\\:\\:testRenameNodeParagraphFieldNotDeletedPostCron\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_core/tests/src/Kernel/FieldRenameHelperTest.php
+
+		-
+			message: "#^Function localgov_demo_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_demo/localgov_demo.install
+
+		-
+			message: "#^Function localgov_demo_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_demo/localgov_demo.module
+
+		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_requirements\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_update_8002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_update_8003\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_update_8004\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_update_8005\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_update_8006\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_update_8007\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Function localgov_directories_update_8008\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_directories/localgov_directories.install
 
@@ -11,9 +576,144 @@ parameters:
 			path: web/modules/contrib/localgov_directories/localgov_directories.module
 
 		-
+			message: "#^Function localgov_directories_entity_extra_field_info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_facets_facet_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_facets_search_api_query_type_mapping_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_field_config_delete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_field_config_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_form_facets_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_leaflet_map_view_style_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_node_view\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_optional_fields_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_pathauto_pattern_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_preprocess_facets_item_list\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_search_api_index_items_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_search_api_index_update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_theme_suggestions_checkboxes_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function template_preprocess_checkboxes__localgov_directories_facets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function template_preprocess_localgov_directories_facets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Function localgov_directories_post_update_replace_node_type_condition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.post_update.php
+
+		-
+			message: "#^Function localgov_directories_post_update_replace_node_type_condition_again\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.post_update.php
+
+		-
+			message: "#^Function localgov_directories_db_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_db/localgov_directories_db.install
+
+		-
+			message: "#^Function localgov_directories_db_uninstall\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_db/localgov_directories_db.install
+
+		-
 			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
 			count: 1
 			path: web/modules/contrib/localgov_directories/modules/localgov_directories_db/tests/Kernel/InstallTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_db\\\\Kernel\\\\InstallTest\\:\\:testEnableModule\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_db/tests/Kernel/InstallTest.php
+
+		-
+			message: "#^Function localgov_directories_location_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.install
+
+		-
+			message: "#^Function localgov_directories_location_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.install
+
+		-
+			message: "#^Function localgov_directories_location_update_8003\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.install
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
@@ -21,14 +721,199 @@ parameters:
 			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.module
 
 		-
+			message: "#^Function localgov_directories_location_entity_extra_field_info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.module
+
+		-
+			message: "#^Function localgov_directories_location_field_config_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.module
+
+		-
+			message: "#^Function localgov_directories_location_node_view\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.module
+
+		-
+			message: "#^Function localgov_directories_location_search_api_index_update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories_location\\\\EventSubscriber\\\\SearchApiSubscriber\\:\\:queryPreExecute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/src/EventSubscriber/SearchApiSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories_location\\\\LocationExtraFieldDisplay\\:\\:entityExtraFieldInfo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories_location\\\\LocationExtraFieldDisplay\\:\\:getViewEmbed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories_location\\\\LocationExtraFieldDisplay\\:\\:nodeView\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories_location\\\\LocationExtraFieldDisplay\\:\\:removeExposedFilter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/src/ProximitySearchSetup.php
 
 		-
+			message: "#^Method Drupal\\\\localgov_directories_location\\\\ProximitySearchSetup\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/src/ProximitySearchSetup.php
+
+		-
+			message: "#^Function localgov_directories_or_localgov_openreferral_mapping_delete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/localgov_directories_or.module
+
+		-
+			message: "#^Function localgov_directories_or_localgov_openreferral_mapping_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/localgov_directories_or.module
+
+		-
+			message: "#^Function localgov_directories_or_node_delete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/localgov_directories_or.module
+
+		-
+			message: "#^Function localgov_directories_or_node_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/localgov_directories_or.module
+
+		-
+			message: "#^Function localgov_directories_or_node_update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/localgov_directories_or.module
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
 			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/src/FacetMapping.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories_or\\\\FacetMapping\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/src/FacetMapping.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories_or\\\\FacetMapping\\:\\:synchroniseFacetMappings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/src/FacetMapping.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_or\\\\Kernel\\\\FacetSyncTest\\:\\:testSyncroniseFacetMappings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/tests/src/Kernel/FacetSyncTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_org\\\\Functional\\\\DirectoryOrgTest\\:\\:testDirectoryVenueFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_org/tests/Functional/DirectoryOrgTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_org\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_org/tests/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Function localgov_directories_page_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_page/localgov_directories_page.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_page\\\\Functional\\\\DirectoryPageTest\\:\\:testDirectoryPageFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_page/tests/src/Functional/DirectoryPageTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_page\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testDirectoryIntegration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_page/tests/src/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_page\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_page/tests/src/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_page\\\\Kernel\\\\RolesIntegrationTest\\:\\:testEnablingRolesModule\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_page/tests/src/Kernel/RolesIntegrationTest.php
+
+		-
+			message: "#^Function localgov_directories_promo_page_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
+
+		-
+			message: "#^Function localgov_directories_promo_page_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_promo_page/localgov_directories_promo_page.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_promo_page\\\\Functional\\\\DirectoryPromoPageTest\\:\\:testDirectoryPromoPageFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_promo_page/tests/src/Functional/DirectoryPromoPageTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_promo_page\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_promo_page/tests/src/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_promo_page\\\\Kernel\\\\RolesIntegrationTest\\:\\:testEnablingRolesModule\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_promo_page/tests/src/Kernel/RolesIntegrationTest.php
+
+		-
+			message: "#^Function localgov_directories_venue_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_venue/localgov_directories_venue.install
+
+		-
+			message: "#^Function localgov_directories_venue_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_venue/localgov_directories_venue.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_venue\\\\Functional\\\\DirectoryVenueTest\\:\\:testDirectoryVenueFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_venue/tests/src/Functional/DirectoryVenueTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_venue\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_venue/tests/src/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories_venue\\\\Kernel\\\\RolesIntegrationTest\\:\\:testEnablingRolesModule\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_venue/tests/src/Kernel/RolesIntegrationTest.php
+
+		-
+			message: "#^Function localgov_directories_venue_or_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_venue_or/localgov_directories_venue_or.install
+
+		-
+			message: "#^Function localgov_directories_venue_or_prepopulate_org\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_venue_or/localgov_directories_venue_or.module
 
 		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
@@ -41,13 +926,128 @@ parameters:
 			path: web/modules/contrib/localgov_directories/src/ConfigurationHelper.php
 
 		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\ConfigurationHelper\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/ConfigurationHelper.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\DirectoryExtraFieldDisplay\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/DirectoryExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\DirectoryExtraFieldDisplay\\:\\:entityExtraFieldInfo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/DirectoryExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\DirectoryExtraFieldDisplay\\:\\:getFacetsBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/DirectoryExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\DirectoryExtraFieldDisplay\\:\\:getSearchBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/DirectoryExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\DirectoryExtraFieldDisplay\\:\\:getViewEmbed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/DirectoryExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\DirectoryExtraFieldDisplay\\:\\:nodeView\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/DirectoryExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\DirectoryExtraFieldDisplay\\:\\:preprocessFacetList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/DirectoryExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\DirectoryExtraFieldDisplay\\:\\:removeExposedFilter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/DirectoryExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Entity\\\\LocalgovDirectoriesFacets\\:\\:getWeight\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Entity/LocalgovDirectoriesFacets.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Entity\\\\LocalgovDirectoriesFacets\\:\\:preCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Entity/LocalgovDirectoriesFacets.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Entity\\\\LocalgovDirectoriesFacets\\:\\:setWeight\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Entity/LocalgovDirectoriesFacets.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\EventSubscriber\\\\DirectoriesConfigSubscriber\\:\\:onExportTransform\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/EventSubscriber/DirectoriesConfigSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\EventSubscriber\\\\DirectoriesConfigSubscriber\\:\\:onImportTransform\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/EventSubscriber/DirectoriesConfigSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Form\\\\LocalgovDirectoriesFacetsForm\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Form/LocalgovDirectoriesFacetsForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Form\\\\LocalgovDirectoriesFacetsTypeForm\\:\\:form\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Form/LocalgovDirectoriesFacetsTypeForm.php
+
+		-
+			message: "#^Method class@anonymous/modules/contrib/localgov_directories/src/Plugin/Block/ChannelSearchBlock\\.php\\:79\\:\\:getSearchBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/Block/ChannelSearchBlock.php
+
+		-
 			message: "#^Parameter \\#2 \\$callback of function array_reduce expects callable\\(array\\<string\\>, Drupal\\\\Core\\\\Entity\\\\EntityInterface\\)\\: array\\<string\\>, Closure\\(array, Drupal\\\\node\\\\NodeInterface\\)\\: array\\<string\\> given\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_directories/src/Plugin/Block/ChannelSearchBlock.php
 
 		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Plugin\\\\EntityReferenceSelection\\\\LocalgovDirectoriesChannelsSelection\\:\\:validateConfigurationForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesChannelsSelection.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Plugin\\\\Field\\\\FieldWidget\\\\ChannelFieldWidget\\:\\:validateElement\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/Field/FieldWidget/ChannelFieldWidget.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Plugin\\\\Field\\\\FieldWidget\\\\FacetFieldWidget\\:\\:validateElement\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/Field/FieldWidget/FacetFieldWidget.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Plugin\\\\facets\\\\processor\\\\LocalGovDirectoriesProcessor\\:\\:preQuery\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/facets/processor/LocalGovDirectoriesProcessor.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 3
+			path: web/modules/contrib/localgov_directories/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Plugin\\\\facets\\\\query_type\\\\LocalGovDirectoriesQueryType\\:\\:build\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_directories\\\\Plugin\\\\facets\\\\query_type\\\\LocalGovDirectoriesQueryType\\:\\:execute\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/modules/contrib/localgov_directories/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
 
 		-
@@ -61,9 +1061,74 @@ parameters:
 			path: web/modules/contrib/localgov_directories/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
 
 		-
-			message: "#^Method Drupal\\\\Tests\\\\BrowserTestBase\\:\\:drupalLogout\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Functional\\\\ChannelFacetsWidgetAdminTest\\:\\:testDirectoryChannelWidget\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Functional\\\\FacetsTest\\:\\:testFacetSearchShowsAccessibleFacet\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_directories/tests/src/Functional/FacetsTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Functional\\\\FacetsTest\\:\\:testFacetsGroupFilters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Functional/FacetsTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testServicesIntegration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Functional\\\\ResetFacetFilterTest\\:\\:testShowResetFilterLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Functional/ResetFacetFilterTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\FunctionalJavascript\\\\EntityReferenceFacetsWidgetTest\\:\\:testDirectoryChannelWidget\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/FunctionalJavascript/EntityReferenceFacetsWidgetTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\FunctionalJavascript\\\\EntityReferenceFacetsWidgetTest\\:\\:testFacetRequired\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/FunctionalJavascript/EntityReferenceFacetsWidgetTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Kernel\\\\EntityReferenceChannelsSelectionTest\\:\\:testSelectionHandler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Kernel/EntityReferenceChannelsSelectionTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Kernel\\\\EntityReferenceDirectoryEntryTypesTest\\:\\:testSelectionHandler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Kernel/EntityReferenceDirectoryEntryTypesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Kernel\\\\FacetIndexFieldSetupTest\\:\\:testFacetIndexFieldCreation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Kernel/FacetIndexFieldSetupTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Kernel\\\\IgnoreTypeConfigTest\\:\\:testExcludedModules\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Kernel/IgnoreTypeConfigTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Kernel\\\\IndexTitleSortTest\\:\\:testItemsSortValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Kernel/IndexTitleSortTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Kernel\\\\RolesIntegrationTest\\:\\:testEnablingRolesModule\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Kernel/RolesIntegrationTest.php
 
 		-
 			message: "#^Call to method Drupal\\\\Tests\\\\UnitTestCase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
@@ -71,14 +1136,259 @@ parameters:
 			path: web/modules/contrib/localgov_directories/tests/src/Unit/FacetPreprocessTest.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 2
+			message: "#^Method Drupal\\\\Tests\\\\localgov_directories\\\\Unit\\\\FacetPreprocessTest\\:\\:testFacetTypeSorting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Unit/FacetPreprocessTest.php
+
+		-
+			message: "#^Function localgov_events_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.install
+
+		-
+			message: "#^Function localgov_events_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.install
+
+		-
+			message: "#^Function localgov_events_update_8002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.install
+
+		-
+			message: "#^Function localgov_events_form_node_localgov_event_edit_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Function localgov_events_form_node_localgov_event_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Function localgov_events_form_views_exposed_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Function localgov_events_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Function localgov_events_optional_fields_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Function localgov_events_page_attachments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Function localgov_events_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Function localgov_events_views_pre_view\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_events\\\\Form\\\\EventsAddEditCallbacks\\:\\:configureNodeForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/src/Form/EventsAddEditCallbacks.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_events\\\\Form\\\\EventsAddEditCallbacks\\:\\:submitHandler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/src/Form/EventsAddEditCallbacks.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_events\\\\Functional\\\\EventPageTest\\:\\:testEventFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/tests/src/Functional/EventPageTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_events\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_events/tests/src/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Function localgov_geo_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.install
+
+		-
+			message: "#^Function localgov_geo_update_10001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.install
+
+		-
+			message: "#^Function localgov_geo_update_last_removed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.install
+
+		-
+			message: "#^Function localgov_geo_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.module
+
+		-
+			message: "#^Function localgov_geo_menu_local_actions_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.module
+
+		-
+			message: "#^Function localgov_geo_menu_local_tasks_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.module
+
+		-
+			message: "#^Function localgov_geo_preprocess_breadcrumb\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.module
+
+		-
+			message: "#^Function localgov_geo_preprocess_html\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.module
+
+		-
+			message: "#^Function localgov_geo_preprocess_page_title\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/localgov_geo.module
 
 		-
 			message: "#^Call to static method Drupal\\\\Component\\\\Utility\\\\Html\\:\\:escape\\(\\) with incorrect case\\: Escape$#"
 			count: 1
 			path: web/modules/contrib/localgov_geo/modules/localgov_geo_address/tests/Functional/AddressFormsTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_geo_address\\\\Functional\\\\AddressFormsTest\\:\\:testCrud\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_address/tests/Functional/AddressFormsTest.php
+
+		-
+			message: "#^Function localgov_geo_update_deploy_geo_entity_conversion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.deploy.php
+
+		-
+			message: "#^Function localgov_geo_update_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_8002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_8003\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_8004\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_8005\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_8806\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_8807\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_8808\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_8809\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Function localgov_geo_update_update_dependencies\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/localgov_geo_update.install
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:getCreatedTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:getOwner\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:getOwnerId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:isEnabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:preCreate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:presave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:setCreatedTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:setOwner\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:setOwnerId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeo\\:\\:setStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeo.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\Entity\\\\LocalgovGeoType\\:\\:labelToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/Entity/LocalgovGeoType.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\MigrateDisplayModes\\:\\:migrate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/MigrateDisplayModes.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_geo_update\\\\MigrateDisplayModes\\:\\:migrateBaseDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/MigrateDisplayModes.php
 
 		-
 			message: "#^Undefined variable\\: \\$new_config$#"
@@ -101,79 +1411,1004 @@ parameters:
 			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/src/Element/AutocompleteAddress.php
 
 		-
+			message: "#^Method Drupal\\\\localgov_geo_update_to_geo_test\\\\Plugin\\\\Field\\\\FieldWidget\\\\AutocompleteAddress\\:\\:validateProvidersSettingsForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/src/Plugin/Field/FieldWidget/AutocompleteAddress.php
+
+		-
 			message: "#^Parameter \\#2 \\$callback of function uasort expects callable\\(Drupal\\\\Core\\\\Entity\\\\EntityInterface, Drupal\\\\Core\\\\Entity\\\\EntityInterface\\)\\: int, Closure\\(Drupal\\\\geocoder\\\\Entity\\\\GeocoderProvider, Drupal\\\\geocoder\\\\Entity\\\\GeocoderProvider\\)\\: \\(\\-1\\|0\\|1\\) given\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/src/Plugin/Field/FieldWidget/AutocompleteAddress.php
 
 		-
-			message: "#^Variable \\$overview might not be defined\\.$#"
-			count: 2
-			path: web/modules/contrib/localgov_guides/src/Plugin/PreviewLinkAutopopulate/Guides.php
+			message: "#^Method Drupal\\\\Tests\\\\localgov_geo_update\\\\Functional\\\\UpdateLocalgovGeoTest\\:\\:testUpdateOfLocalgovGeo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/tests/src/Functional/UpdateLocalgovGeoTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_walk expects callable\\(Drupal\\\\Core\\\\Entity\\\\EntityInterface, int\\|string\\)\\: mixed, array\\{Drupal\\\\localgov_menu_link_group\\\\MenuLinkGrouper, 'groupChildMenuLinks'\\} given\\.$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_geo\\\\Functional\\\\GeoBundleCreationTest\\:\\:testMediaTypeCreationForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/tests/src/Functional/GeoBundleCreationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_geo\\\\Functional\\\\GeoOverviewAccessTest\\:\\:testOverviewPageAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/tests/src/Functional/GeoOverviewAccessTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_geo\\\\Functional\\\\GeoTitleRenameTest\\:\\:testGeoRenamedToLocation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/tests/src/Functional/GeoTitleRenameTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_geo\\\\Kernel\\\\RolesIntegrationTest\\:\\:testEnablingRolesModule\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/tests/src/Kernel/RolesIntegrationTest.php
+
+		-
+			message: "#^Function localgov_guides_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.install
+
+		-
+			message: "#^Function localgov_guides_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_node_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_node_prepare_form\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_node_presave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_node_update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_optional_fields_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_preprocess_html\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_preprocess_node__localgov_guides_overview__full\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Function localgov_guides_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/localgov_guides.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_guides\\\\ChildParentRelationship\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/src/ChildParentRelationship.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_guides\\\\ChildParentRelationship\\:\\:overviewPagesCheck\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/src/ChildParentRelationship.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_guides\\\\ChildParentRelationship\\:\\:pageUpdateOverview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/src/ChildParentRelationship.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_guides\\\\EventSubscriber\\\\PageHeaderSubscriber\\:\\:setPageHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/src/EventSubscriber/PageHeaderSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_guides\\\\Plugin\\\\Block\\\\GuidesAbstractBaseBlock\\:\\:setPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/src/Plugin/Block/GuidesAbstractBaseBlock.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_guides\\\\Plugin\\\\Block\\\\GuidesPrevNextBlock\\:\\:submitConfigurationForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/src/Plugin/Block/GuidesPrevNextBlock.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\ContentsBlockTest\\:\\:testContentListBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/ContentsBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\ContentsBlockTest\\:\\:testContentsBlockVisibility\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/ContentsBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\GuidePagesTest\\:\\:testConfigForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/GuidePagesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\GuidePagesTest\\:\\:testUnpublishedGuidePages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/GuidePagesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\PageHeaderBlockTest\\:\\:testGuidePageHeaderBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/PageHeaderBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\PagesIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\PagesIntegrationTest\\:\\:testPagePath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\PagesIntegrationTest\\:\\:testServicesIntegration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\PagesIntegrationTest\\:\\:testTopicIntegration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Functional\\\\PrevNextBlockTest\\:\\:testPrevNextBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Functional/PrevNextBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_guides\\\\Kernel\\\\OverviewPageIntegrity\\:\\:testServiceParentAddition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_guides/tests/src/Kernel/OverviewPageIntegrity.php
+
+		-
+			message: "#^Function _localgov_menu_link_group_filter_menu\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_menu_link_group/localgov_menu_link_group.module
 
 		-
-			message: "#^Parameter \\#1 \\$group of method Drupal\\\\localgov_menu_link_group\\\\Controller\\\\LocalGovMenuLinkGroupListBuilder\\:\\:determineParentMenuLinkLabel\\(\\) expects Drupal\\\\localgov_menu_link_group\\\\Entity\\\\LocalGovMenuLinkGroupInterface, Drupal\\\\Core\\\\Entity\\\\EntityInterface given\\.$#"
+			message: "#^Function localgov_menu_link_group_localgov_menu_link_group_delete\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: web/modules/contrib/localgov_menu_link_group/src/Controller/LocalGovMenuLinkGroupListBuilder.php
+			path: web/modules/contrib/localgov_menu_link_group/localgov_menu_link_group.module
 
 		-
-			message: "#^Dynamic call to static method Drupal\\\\localgov_menu_link_group\\\\Form\\\\LocalGovMenuLinkGroupForm\\:\\:prepareMenuLinkOption\\(\\)\\.$#"
+			message: "#^Function localgov_menu_link_group_localgov_menu_link_group_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/localgov_menu_link_group.module
+
+		-
+			message: "#^Function localgov_menu_link_group_localgov_menu_link_group_update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/localgov_menu_link_group.module
+
+		-
+			message: "#^Function localgov_menu_link_group_menu_links_discovered_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/localgov_menu_link_group.module
+
+		-
+			message: "#^Function localgov_menu_link_group_module_implements_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/localgov_menu_link_group.module
+
+		-
+			message: "#^Function localgov_menu_link_group_preprocess_menu\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/localgov_menu_link_group.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_menu_link_group\\\\Form\\\\LocalGovMenuLinkGroupForm\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_menu_link_group/src/Form/LocalGovMenuLinkGroupForm.php
 
 		-
-			message: "#^Class DOMXPath referenced with incorrect case\\: DomXPath\\.$#"
-			count: 2
+			message: "#^Method Drupal\\\\localgov_menu_link_group\\\\Form\\\\LocalGovMenuLinkGroupForm\\:\\:exist\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/src/Form/LocalGovMenuLinkGroupForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_menu_link_group\\\\Form\\\\LocalGovMenuLinkGroupForm\\:\\:form\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/src/Form/LocalGovMenuLinkGroupForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_menu_link_group\\\\Form\\\\LocalGovMenuLinkGroupForm\\:\\:massageFormValues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/src/Form/LocalGovMenuLinkGroupForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_menu_link_group\\\\Form\\\\LocalGovMenuLinkGroupForm\\:\\:validateForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/src/Form/LocalGovMenuLinkGroupForm.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_menu_link_group\\\\Kernel\\\\CrossMenuAssignmentTest\\:\\:testFormSubmission\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/tests/src/Kernel/CrossMenuAssignmentTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_menu_link_group\\\\Kernel\\\\GroupAccessTest\\:\\:testGroupAccess\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/modules/contrib/localgov_menu_link_group/tests/src/Kernel/GroupAccessTest.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 2
+			message: "#^Method Drupal\\\\Tests\\\\localgov_menu_link_group\\\\Kernel\\\\GroupConfigImportTest\\:\\:testDuplicateGroup\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/modules/contrib/localgov_menu_link_group/tests/src/Kernel/GroupConfigImportTest.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 2
-			path: web/modules/contrib/localgov_publications/localgov_publications.install
+			message: "#^Method Drupal\\\\Tests\\\\localgov_menu_link_group\\\\Kernel\\\\GroupConfigImportTest\\:\\:testMenuLinkAlteration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_menu_link_group/tests/src/Kernel/GroupConfigImportTest.php
 
 		-
-			message: "#^Variable \\$themeInfo in empty\\(\\) always exists and is not falsy\\.$#"
+			message: "#^Function localgov_news_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/localgov_news.install
+
+		-
+			message: "#^Function localgov_news_entity_extra_field_info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/localgov_news.module
+
+		-
+			message: "#^Function localgov_news_field_widget_complete_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/localgov_news.module
+
+		-
+			message: "#^Function localgov_news_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/localgov_news.module
+
+		-
+			message: "#^Function localgov_news_node_view\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/localgov_news.module
+
+		-
+			message: "#^Function localgov_news_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/localgov_news.module
+
+		-
+			message: "#^Function localgov_news_tokens_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/localgov_news.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\EventSubscriber\\\\PageHeaderSubscriber\\:\\:setPageHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/EventSubscriber/PageHeaderSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:articleSetNewsroomPromote\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:articleSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:articleUnsetNewsroomPromote\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:entityExtraFieldInfo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:formAlter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:getFacetsBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:getSearchBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:getViewEmbed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:nodeView\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_news\\\\NewsExtraFieldDisplay\\:\\:rssEntityView\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/src/NewsExtraFieldDisplay.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_news\\\\Functional\\\\NewsPageTest\\:\\:testNewsEditForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/tests/src/Functional/NewsPageTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_news\\\\Functional\\\\NewsPageTest\\:\\:testNewsEditPromoteCheckbox\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/tests/src/Functional/NewsPageTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_news\\\\Functional\\\\NewsPageTest\\:\\:testNewsFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/tests/src/Functional/NewsPageTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_news\\\\Functional\\\\NewsPageTest\\:\\:testNewsPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/tests/src/Functional/NewsPageTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_news\\\\Functional\\\\NewsSearchTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/tests/src/Functional/NewsSearchTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_news\\\\Functional\\\\NewsSearchTest\\:\\:testNewsSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/tests/src/Functional/NewsSearchTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_news\\\\FunctionalJavascript\\\\PromotedNewsWidgetTest\\:\\:testPromoteAutocompleteWidget\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_news/tests/src/FunctionalJavascript/PromotedNewsWidgetTest.php
+
+		-
+			message: "#^Function localgov_openreferral_entity_presave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/localgov_openreferral.module
+
+		-
+			message: "#^Function localgov_openreferral_localgov_openreferral_mapping_delete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/localgov_openreferral.module
+
+		-
+			message: "#^Function localgov_openreferral_localgov_openreferral_mapping_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/localgov_openreferral.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Controller\\\\EndpointsController\\:\\:initializePager\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Controller/EndpointsController.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Controller\\\\EndpointsController\\:\\:single\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Controller/EndpointsController.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Controller\\\\EndpointsController\\:\\:taxonomies\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Controller/EndpointsController.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Controller\\\\EndpointsController\\:\\:vocabulary\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Controller/EndpointsController.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Entity\\\\PropertyMapping\\:\\:setMapping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Entity/PropertyMapping.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Entity\\\\PropertyMapping\\:\\:setPublicDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Entity/PropertyMapping.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Entity\\\\PropertyMapping\\:\\:setPublicType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Entity/PropertyMapping.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Entity\\\\PropertyMappingInterface\\:\\:setMapping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Entity/PropertyMappingInterface.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Entity\\\\PropertyMappingInterface\\:\\:setPublicDataType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Entity/PropertyMappingInterface.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Entity\\\\PropertyMappingInterface\\:\\:setPublicType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Entity/PropertyMappingInterface.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\DefaultExceptionSubscriber\\:\\:onException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/DefaultExceptionSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\DefaultExceptionSubscriber\\:\\:setEventResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/DefaultExceptionSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\GenerateMappingBase\\:\\:generateSuggestions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/GenerateMappingBase.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\GenerateMappingBasic\\:\\:generateSuggestions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/GenerateMappingBasic.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\GenerateMappingLocation\\:\\:generateSuggestions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/GenerateMappingLocation.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\GenerateMappingOrganization\\:\\:generateSuggestions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/GenerateMappingOrganization.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\GenerateMappingService\\:\\:generateSuggestions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/GenerateMappingService.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\GenerateMappingTaxonomy\\:\\:generateSuggestions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/GenerateMappingTaxonomy.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\EventSubscriber\\\\RequestTypes\\:\\:onKernelRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/EventSubscriber/RequestTypes.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Form\\\\PropertyMappingForm\\:\\:addRow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Form/PropertyMappingForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Form\\\\PropertyMappingForm\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Form/PropertyMappingForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Form\\\\PropertyMappingForm\\:\\:form\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Form/PropertyMappingForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Form\\\\PropertyMappingForm\\:\\:getBundles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Form/PropertyMappingForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Form\\\\PropertyMappingForm\\:\\:populateMapping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Form/PropertyMappingForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Form\\\\PropertyMappingForm\\:\\:refreshMappingAjax\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Form/PropertyMappingForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Form\\\\PropertyMappingForm\\:\\:validateForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Form/PropertyMappingForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\MappingInformation\\:\\:getInternalTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/MappingInformation.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\ParamConverter\\\\EntityUuidConverter\\:\\:setLanguageManager\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/ParamConverter/EntityUuidConverter.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Plugin\\\\search_api\\\\processor\\\\AddOrTaxonomyMetadata\\:\\:addFieldValues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Plugin/search_api/processor/AddOrTaxonomyMetadata.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Plugin\\\\views\\\\row\\\\SearchApiDataRow\\:\\:init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Plugin/views/row/SearchApiDataRow.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Plugin\\\\views\\\\row\\\\SearchApiDataRow\\:\\:query\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Plugin/views/row/SearchApiDataRow.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Plugin\\\\views\\\\style\\\\Serializer\\:\\:pagination\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Plugin/views/style/Serializer.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\Plugin\\\\views\\\\style\\\\Serializer\\:\\:render\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/Plugin/views/style/Serializer.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\SearchApiIndexConfig\\:\\:addToServicesIndex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/SearchApiIndexConfig.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\SearchApiIndexConfig\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/SearchApiIndexConfig.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_openreferral\\\\SearchApiIndexConfig\\:\\:removeFromServicesIndex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/src/SearchApiIndexConfig.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_openreferral\\\\Functional\\\\ResourceTest\\:\\:testPermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/tests/src/Functional/ResourceTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_openreferral\\\\Functional\\\\ResourceTest\\:\\:testUnpublishedAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/tests/src/Functional/ResourceTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_openreferral\\\\Kernel\\\\RequestPagerTest\\:\\:testOpenreferralFindPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_openreferral/tests/src/Kernel/RequestPagerTest.php
+
+		-
+			message: "#^Function localgov_page_components_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.install
+
+		-
+			message: "#^Function localgov_page_components_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.install
+
+		-
+			message: "#^Function localgov_page_components_entity_presave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.module
+
+		-
+			message: "#^Function localgov_page_components_entity_type_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.module
+
+		-
+			message: "#^Function localgov_page_components_field_widget_multivalue_entity_browser_entity_reference_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.module
+
+		-
+			message: "#^Function localgov_page_components_help\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.module
+
+		-
+			message: "#^Function localgov_page_components_local_tasks_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.module
+
+		-
+			message: "#^Function localgov_page_components_menu_links_discovered_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.module
+
+		-
+			message: "#^Function localgov_page_components_menu_local_actions_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.module
+
+		-
+			message: "#^Function localgov_page_components_views_pre_render\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/localgov_page_components.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_page_components\\\\Kernel\\\\LinkItIntegrationTest\\:\\:testLinkItSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/tests/src/Kernel/LinkItIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_page_components\\\\Kernel\\\\LinkItIntegrationTest\\:\\:testLinkItSubstitution\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_page_components/tests/src/Kernel/LinkItIntegrationTest.php
+
+		-
+			message: "#^Function localgov_paragraphs_update_9001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/localgov_paragraphs.install
+
+		-
+			message: "#^Function localgov_paragraphs_update_9002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/localgov_paragraphs.install
+
+		-
+			message: "#^Function localgov_paragraphs_update_9003\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/localgov_paragraphs.install
+
+		-
+			message: "#^Function localgov_paragraphs_update_9004\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/localgov_paragraphs.install
+
+		-
+			message: "#^Function localgov_paragraphs_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/localgov_paragraphs.module
+
+		-
+			message: "#^Function localgov_homepage_paragraphs_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.install
+
+		-
+			message: "#^Function localgov_homepage_paragraphs_preprocess_paragraph\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.module
+
+		-
+			message: "#^Function localgov_homepage_paragraphs_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.module
+
+		-
+			message: "#^Function localgov_homepage_paragraphs_dummy_content_type_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_homepage_paragraphs/tests/modules/localgov_homepage_paragraphs_dummy_content_type/localgov_homepage_paragraphs_dummy_content_type.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_homepage_paragraphs\\\\Functional\\\\HomepageAddTest\\:\\:testCreateHomepage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_homepage_paragraphs/tests/src/Functional/HomepageAddTest.php
+
+		-
+			message: "#^Function localgov_paragraphs_layout_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.module
+
+		-
+			message: "#^Function localgov_paragraphs_layout_post_update_fix_missing_layout_paragraphs_setting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.post_update.php
+
+		-
+			message: "#^Function localgov_paragraphs_views_preprocess_paragraph\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_paragraphs_views/localgov_paragraphs_views.module
+
+		-
+			message: "#^Function localgov_subsites_paragraphs_update_10001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
+
+		-
+			message: "#^Function localgov_subsites_paragraphs_preprocess_paragraph\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module
+
+		-
+			message: "#^Function localgov_subsites_paragraphs_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_subsites_paragraphs\\\\Functional\\\\SubsitesParagraphsAdministrationTest\\:\\:testSubsiteParagraphsTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/modules/localgov_subsites_paragraphs/tests/src/Functional/SubsitesParagraphsAdministrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_paragraphs\\\\Functional\\\\ParagraphsAdministrationTest\\:\\:testParagraphsCreation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/tests/src/Functional/ParagraphsAdministrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_paragraphs\\\\Functional\\\\ParagraphsAdministrationTest\\:\\:testParagraphsTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/tests/src/Functional/ParagraphsAdministrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_paragraphs\\\\Kernel\\\\CheckConfigTest\\:\\:testConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_paragraphs/tests/src/Kernel/CheckConfigTest.php
+
+		-
+			message: "#^Function localgov_publications_install\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_publications/localgov_publications.install
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 2
+			message: "#^Function localgov_publications_update_10001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/localgov_publications.install
+
+		-
+			message: "#^Function localgov_publications_update_10002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/localgov_publications.install
+
+		-
+			message: "#^Function localgov_publications_block_access\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/modules/contrib/localgov_publications/localgov_publications.module
 
 		-
-			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\PublicationCoverPageTest\\:\\:\\$nodeStorage\\.$#"
+			message: "#^Function localgov_publications_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/localgov_publications.module
+
+		-
+			message: "#^Function localgov_publications_token_info_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/localgov_publications.tokens.inc
+
+		-
+			message: "#^Function localgov_publications_tokens_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/localgov_publications.tokens.inc
+
+		-
+			message: "#^Method Drupal\\\\localgov_publications\\\\Controller\\\\LocalgovPublicationsBookController\\:\\:build\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/src/Controller/LocalgovPublicationsBookController.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_publications\\\\EventSubscriber\\\\LocalgovPublicationsRouteSubscriber\\:\\:alterRoutes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/src/EventSubscriber/LocalgovPublicationsRouteSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_publications\\\\Plugin\\\\Block\\\\PublicationNavigationBlock\\:\\:setActiveClass\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/src/Plugin/Block/PublicationNavigationBlock.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_publications\\\\Token\\\\Hooks\\:\\:bookParents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/src/Token/Hooks.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_publications\\\\Token\\\\Hooks\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/src/Token/Hooks.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_publications\\\\Token\\\\Hooks\\:\\:tokensAlter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/src/Token/Hooks.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\AdminTest\\:\\:testPublicationsAreNotListedOnBookOverview\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/AdminTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\ChildLinkTest\\:\\:testAddChildPageLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/ChildLinkTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\PublicationCoverPageTest\\:\\:testPublicationCoverPageFields\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_publications/tests/src/Functional/PublicationCoverPageTest.php
 
 		-
-			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\PublicationPageTest\\:\\:\\$nodeStorage\\.$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\PublicationPageHeadingBlockTest\\:\\:testHeadingBlockIsConsistent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/PublicationPageHeadingBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\PublicationPageNavigationTest\\:\\:testBookNavigationIsNotDisplayed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/PublicationPageNavigationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\PublicationPageNavigationTest\\:\\:testPreviousNextLinks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/PublicationPageNavigationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\PublicationPageTest\\:\\:testPublicationPageFields\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_publications/tests/src/Functional/PublicationPageTest.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\ReinstallTest\\:\\:testReinstall\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/ReinstallTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\TocBlockTest\\:\\:contentProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/TocBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\TocBlockTest\\:\\:testTocBlockDisplays\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/TocBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\UrlAliasTest\\:\\:testPublicationCoverPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/UrlAliasTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\UrlAliasTest\\:\\:testPublicationPageWithCoverPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/UrlAliasTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\UrlAliasTest\\:\\:testPublicationPageWithCustomAlias\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/UrlAliasTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Functional\\\\UrlAliasTest\\:\\:testPublicationPageWithoutCoverPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Functional/UrlAliasTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Unit\\\\HeadingFinderTest\\:\\:contentProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Unit/HeadingFinderTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_publications\\\\Unit\\\\HeadingFinderTest\\:\\:testSearchMarkup\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_publications/tests/src/Unit/HeadingFinderTest.php
+
+		-
+			message: "#^Function localgov_search_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/localgov_search.install
+
+		-
+			message: "#^Function localgov_search_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/localgov_search.install
+
+		-
+			message: "#^Function localgov_search_update_8002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/localgov_search.install
+
+		-
+			message: "#^Function localgov_search_entity_bundle_create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/localgov_search.module
+
+		-
+			message: "#^Function localgov_search_help\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/localgov_search.module
+
+		-
+			message: "#^Function localgov_search_preprocess_form\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/localgov_search.module
+
+		-
+			message: "#^Function localgov_search_views_pre_render\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/localgov_search.module
+
+		-
+			message: "#^Function localgov_search_db_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/modules/localgov_search_db/localgov_search_db.install
+
+		-
+			message: "#^Function localgov_search_db_uninstall\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/modules/localgov_search_db/localgov_search_db.install
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_search_db\\\\Kernel\\\\InstallTest\\:\\:testEnableModule\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_search/modules/localgov_search_db/tests/Kernel/InstallTest.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_search\\\\Functional\\\\SitewideSearchBase\\:\\:indexItems\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/tests/src/Functional/SitewideSearchBase.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_search\\\\Functional\\\\SitewideSearchBase\\:\\:testSitewideSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/tests/src/Functional/SitewideSearchBase.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_search\\\\Kernel\\\\ContentTypesAddedToSearchTest\\:\\:testSearchViewAndIndexSettings\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_search/tests/src/Kernel/ContentTypesAddedToSearchTest.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Function localgov_search_solr_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search_solr/localgov_search_solr.install
+
+		-
+			message: "#^Function localgov_search_solr_uninstall\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search_solr/localgov_search_solr.install
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_search_solr\\\\Functional\\\\SitewideSearchTest\\:\\:indexItems\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_search_solr/tests/Functional/SitewideSearchTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_search_solr\\\\Kernel\\\\InstallTest\\:\\:testEnableModule\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_search_solr/tests/Kernel/InstallTest.php
+
+		-
+			message: "#^Function localgov_services_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/localgov_services.module
+
+		-
+			message: "#^Function localgov_services_landing_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_landing/localgov_services_landing.install
+
+		-
+			message: "#^Function localgov_services_landing_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_landing/localgov_services_landing.module
 
 		-
 			message: "#^Parameter \\#1 \\$items of method Drupal\\\\Core\\\\Field\\\\Plugin\\\\Field\\\\FieldFormatter\\\\EntityReferenceFormatterBase\\:\\:getEntitiesToView\\(\\) expects Drupal\\\\Core\\\\Field\\\\EntityReferenceFieldItemListInterface, Drupal\\\\Core\\\\Field\\\\FieldItemListInterface given\\.$#"
@@ -181,7 +2416,72 @@ parameters:
 			path: web/modules/contrib/localgov_services/modules/localgov_services_landing/src/Plugin/Field/FieldFormatter/TaxonomyVerticalList.php
 
 		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_landing\\\\Functional\\\\ServicesLandingPageTest\\:\\:testServiceLandingPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_landing/tests/src/Functional/ServicesLandingPageTest.php
+
+		-
+			message: "#^Function localgov_services_navigation_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.install
+
+		-
+			message: "#^Function localgov_services_navigation_entity_extra_field_info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.module
+
+		-
+			message: "#^Function localgov_services_navigation_field_config_delete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.module
+
+		-
+			message: "#^Function localgov_services_navigation_field_config_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.module
+
+		-
+			message: "#^Function localgov_services_navigation_field_widget_single_element_entity_reference_autocomplete_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.module
+
+		-
+			message: "#^Function localgov_services_navigation_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.module
+
+		-
+			message: "#^Function localgov_services_navigation_pathauto_pattern_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.module
+
+		-
+			message: "#^Function localgov_services_navigation_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.module
+
+		-
+			message: "#^Function template_preprocess_localgov_services_navigation_child\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/localgov_services_navigation.module
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_services_navigation\\\\EntityChildRelationshipUi\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_services_navigation\\\\EntityChildRelationshipUi\\:\\:entityExtraFieldInfo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_services_navigation\\\\EntityChildRelationshipUi\\:\\:formAlter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
 
@@ -191,12 +2491,62 @@ parameters:
 			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
 
 		-
+			message: "#^Method Drupal\\\\localgov_services_navigation\\\\EntityReferenceValue\\:\\:valueCallback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/src/EntityReferenceValue.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_services_navigation\\\\Plugin\\\\EntityReferenceSelection\\\\ServicesSelection\\:\\:elementValidateFilter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\FunctionalJavascript\\\\EntityReferenceServicesAutocompleteTest\\:\\:testEntityReferenceAutocompleteWidget\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\FunctionalJavascript\\\\EntityReferenceServicesAutocompleteTest\\:\\:testEntityReferenceSublandingLabelWidget\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\FunctionalJavascript\\\\EntityReferenceServicesAutocompleteTest\\:\\:testServicesEntityReferenceAutocompleteWidget\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\FunctionalJavascript\\\\LandingPageChildrenTest\\:\\:testServiceLandingPageLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\FunctionalJavascript\\\\LandingPageChildrenTest\\:\\:testServiceLandingPageReference\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
 			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
 
 		-
 			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\Kernel\\\\ChildReferencesTest\\:\\:testAddChildTarget\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\Kernel\\\\ChildReferencesTest\\:\\:testChildWithTaxonomy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\Kernel\\\\ChildReferencesTest\\:\\:testReferencedChildren\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
 
@@ -206,52 +2556,577 @@ parameters:
 			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/Kernel/ParentFieldPathautoTest.php
 
 		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_navigation\\\\Kernel\\\\ParentFieldPathautoTest\\:\\:testServiceParentAddition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_navigation/tests/src/Kernel/ParentFieldPathautoTest.php
+
+		-
+			message: "#^Function localgov_services_page_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_page/localgov_services_page.install
+
+		-
+			message: "#^Function localgov_services_page_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_page/localgov_services_page.module
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_page\\\\Functional\\\\ServicesPageTest\\:\\:testServicesPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_page/tests/src/Functional/ServicesPageTest.php
+
+		-
+			message: "#^Function localgov_services_status_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/localgov_services_status.install
+
+		-
+			message: "#^Function localgov_services_status_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/localgov_services_status.install
+
+		-
+			message: "#^Function localgov_services_status_node_presave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/localgov_services_status.module
+
+		-
+			message: "#^Function localgov_services_status_preprocess_node\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/localgov_services_status.module
+
+		-
+			message: "#^Function localgov_services_status_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/localgov_services_status.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_services_status\\\\EventSubscriber\\\\PageHeaderSubscriber\\:\\:setPageHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/src/EventSubscriber/PageHeaderSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_status\\\\Functional\\\\ServiceStatusMessageVisibilityTest\\:\\:testServiceStatusMessageVisibility\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/tests/src/Functional/ServiceStatusMessageVisibilityTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_status\\\\Functional\\\\ServiceStatusTest\\:\\:testServiceStatusListings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_status\\\\Functional\\\\ServiceStatusTest\\:\\:testServiceStatusPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_status\\\\Functional\\\\ServiceStatusTest\\:\\:testServiceStatusPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_status\\\\Kernel\\\\PathTest\\:\\:testProcessInbound\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/tests/src/Kernel/PathTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_status\\\\Kernel\\\\PathTest\\:\\:testProcessOutbound\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_status/tests/src/Kernel/PathTest.php
+
+		-
+			message: "#^Function localgov_services_sublanding_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/localgov_services_sublanding.install
+
+		-
+			message: "#^Function localgov_services_sublanding_preprocess_paragraph__topic_list_builder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/localgov_services_sublanding.module
+
+		-
+			message: "#^Function localgov_services_sublanding_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/localgov_services_sublanding.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_services_sublanding\\\\Plugin\\\\Field\\\\FieldFormatter\\\\LinkNodeReference\\:\\:buildEntityLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/src/Plugin/Field/FieldFormatter/LinkNodeReference.php
+
+		-
+			message: "#^Method Drupal\\\\tests\\\\localgov_services_sublanding\\\\Functional\\\\LinkFormatterTest\\:\\:testExternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/LinkFormatterTest.php
+
+		-
+			message: "#^Method Drupal\\\\tests\\\\localgov_services_sublanding\\\\Functional\\\\LinkFormatterTest\\:\\:testInternalNotEntity\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/LinkFormatterTest.php
+
+		-
+			message: "#^Method Drupal\\\\tests\\\\localgov_services_sublanding\\\\Functional\\\\LinkFormatterTest\\:\\:testNode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/LinkFormatterTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_sublanding\\\\Functional\\\\ServiceSublandingTest\\:\\:testServiceSublandingPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/ServiceSublandingTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services_sublanding\\\\Functional\\\\TopicListBuilderTest\\:\\:testTopicListBuilderParagraphDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/TopicListBuilderTest.php
+
+		-
+			message: "#^Method Drupal\\\\tests\\\\localgov_services_sublanding\\\\Functional\\\\UnpublishedLinkNodeReferenceTest\\:\\:doNotListUnpublishedChildPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReferenceTest.php
+
+		-
+			message: "#^Method Drupal\\\\tests\\\\localgov_services_sublanding\\\\Functional\\\\UnpublishedLinkNodeReferenceTest\\:\\:listPublishedChildPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReferenceTest.php
+
+		-
+			message: "#^Method Drupal\\\\tests\\\\localgov_services_sublanding\\\\Functional\\\\UnpublishedLinkNodeReferenceTest\\:\\:publishChildPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReferenceTest.php
+
+		-
+			message: "#^Method Drupal\\\\tests\\\\localgov_services_sublanding\\\\Functional\\\\UnpublishedLinkNodeReferenceTest\\:\\:testHighlightUnpublishedChildPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReferenceTest.php
+
+		-
+			message: "#^Method Drupal\\\\tests\\\\localgov_services_sublanding\\\\Functional\\\\UnpublishedLinkNodeReferenceTest\\:\\:testOnlyListPublishedChildPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReferenceTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services\\\\Functional\\\\PagesIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services\\\\Functional\\\\PagesIntegrationTest\\:\\:testPostLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services\\\\Functional\\\\PagesIntegrationTest\\:\\:testServicePaths\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services\\\\Functional\\\\ServicesBlockTest\\:\\:testServiceCoreBlocksDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/tests/src/Functional/ServicesBlockTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_services\\\\Functional\\\\WorkflowsIntegrationTest\\:\\:testPostLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_services/tests/src/Functional/WorkflowsIntegrationTest.php
+
+		-
+			message: "#^Function localgov_step_by_step_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.install
+
+		-
+			message: "#^Function localgov_step_by_step_update_8001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.install
+
+		-
+			message: "#^Function localgov_step_by_step_update_8002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.install
+
+		-
+			message: "#^Function localgov_step_by_step_localgov_roles_default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.module
+
+		-
+			message: "#^Function localgov_step_by_step_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.module
+
+		-
+			message: "#^Function localgov_step_by_step_node_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.module
+
+		-
+			message: "#^Function localgov_step_by_step_node_update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.module
+
+		-
+			message: "#^Function localgov_step_by_step_optional_fields_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.module
+
+		-
+			message: "#^Function localgov_step_by_step_preprocess_views_view_list\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.module
+
+		-
+			message: "#^Function localgov_step_by_step_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/localgov_step_by_step.module
+
+		-
 			message: "#^Variable \\$overview might not be defined\\.$#"
 			count: 2
 			path: web/modules/contrib/localgov_step_by_step/src/Plugin/PreviewLinkAutopopulate/StepBySteps.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_step_by_step\\\\Functional\\\\PagesIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_step_by_step\\\\Functional\\\\PagesIntegrationTest\\:\\:testPagePath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_step_by_step\\\\Functional\\\\PagesIntegrationTest\\:\\:testServicesIntegration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_step_by_step\\\\Functional\\\\PagesIntegrationTest\\:\\:testTopicIntegration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/tests/src/Functional/PagesIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_step_by_step\\\\Functional\\\\StepByStepBlocksTest\\:\\:testPartOfStepBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/tests/src/Functional/StepByStepBlocksTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_step_by_step\\\\Functional\\\\StepByStepPagesTest\\:\\:testConfigForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/tests/src/Functional/StepByStepPagesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_step_by_step\\\\FunctionalJavascript\\\\StepByStepSummariesTest\\:\\:testStepSummaryVisibility\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_step_by_step/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
+
+		-
+			message: "#^Function localgov_subsites_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/localgov_subsites.install
+
+		-
+			message: "#^Function localgov_subsites_update_9001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/localgov_subsites.install
+
+		-
+			message: "#^Function localgov_subsites_localgov_roles_default\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_subsites/localgov_subsites.module
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			message: "#^Function localgov_subsites_optional_fields_settings\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: web/modules/contrib/localgov_subsites/src/Plugin/Block/SubsitesAbstractBlockBase.php
+			path: web/modules/contrib/localgov_subsites/localgov_subsites.module
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			message: "#^Function localgov_subsites_preprocess_page\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/localgov_subsites.module
+
+		-
+			message: "#^Function localgov_subsites_theme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/localgov_subsites.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_subsites\\\\EventSubscriber\\\\PageHeaderSubscriber\\:\\:setPageHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/src/EventSubscriber/PageHeaderSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_subsites\\\\Plugin\\\\Block\\\\SubsitesNavigationBlock\\:\\:formatItem\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_subsites/src/Plugin/Block/SubsitesNavigationBlock.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			message: "#^Method Drupal\\\\localgov_subsites\\\\Subsite\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_subsites/src/Subsite.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 2
+			message: "#^Method Drupal\\\\Tests\\\\localgov_subsites\\\\Functional\\\\LocalgovIntegrationTest\\:\\:testLocalgovSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/tests/src/Functional/LocalgovIntegrationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_subsites\\\\Functional\\\\SubsiteBlocksTest\\:\\:testSubsiteBannerBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/tests/src/Functional/SubsiteBlocksTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_subsites\\\\Functional\\\\SubsiteBlocksTest\\:\\:testSubsiteBlocksOnCreateNodePage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/tests/src/Functional/SubsiteBlocksTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_subsites\\\\Functional\\\\SubsiteBlocksTest\\:\\:testSubsiteNavigationBlock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/tests/src/Functional/SubsiteBlocksTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_subsites\\\\Functional\\\\SubsitePagesTest\\:\\:testSubsiteFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/tests/src/Functional/SubsitePagesTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_subsites\\\\Functional\\\\SubsitePagesTest\\:\\:testSubsitePaths\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_subsites/tests/src/Functional/SubsitePagesTest.php
+
+		-
+			message: "#^Function localgov_workflows_install\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/modules/contrib/localgov_workflows/localgov_workflows.install
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 3
+			message: "#^Function localgov_workflows_update_9001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.install
+
+		-
+			message: "#^Function localgov_workflows_update_9002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.install
+
+		-
+			message: "#^Function localgov_workflows_update_9003\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.install
+
+		-
+			message: "#^Function localgov_workflows_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			message: "#^Function localgov_workflows_form_node_type_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_workflows_menu_links_discovered_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_workflows_menu_local_actions_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_workflows_menu_local_tasks_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_workflows_module_implements_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_workflows_modules_installed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_workflows_node_type_insert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_workflows_preprocess_html\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_workflows_preprocess_page_title\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/localgov_workflows.module
+
+		-
+			message: "#^Function localgov_review_date_entity_bundle_field_info\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/localgov_review_date.module
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Function localgov_review_date_form_scheduled_transitions_settings_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/localgov_review_date.module
+
+		-
+			message: "#^Function localgov_review_date_form_scheduled_transitions_settings_submit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/localgov_review_date.module
+
+		-
+			message: "#^Function localgov_review_date_node_update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/localgov_review_date.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Entity\\\\ReviewDate\\:\\:postSave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Entity/ReviewDate.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Entity\\\\ReviewDate\\:\\:setActive\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Entity/ReviewDate.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Entity\\\\ReviewDate\\:\\:setAuthor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Entity/ReviewDate.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Entity\\\\ReviewDate\\:\\:setCreatedTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Entity/ReviewDate.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Entity\\\\ReviewDate\\:\\:setEntity\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Entity/ReviewDate.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Entity\\\\ReviewDate\\:\\:setLangauge\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Entity/ReviewDate.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Entity\\\\ReviewDate\\:\\:setReviewTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Entity/ReviewDate.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Form\\\\ReviewDateSettingsForm\\:\\:getNextReviewOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Form/ReviewDateSettingsForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Form\\\\ReviewDateSettingsForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Form/ReviewDateSettingsForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Plugin\\\\Field\\\\FieldType\\\\ReviewDateItem\\:\\:createScheduledTransition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Plugin/Field/FieldType/ReviewDateItem.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_review_date\\\\Plugin\\\\Field\\\\FieldType\\\\ReviewDateItem\\:\\:preSave\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/src/Plugin/Field/FieldType/ReviewDateItem.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\Functional\\\\AdminSettingsTest\\:\\:testAdminSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/Functional/AdminSettingsTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\Functional\\\\NodeFormTest\\:\\:testNodeForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/Functional/NodeFormTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\Functional\\\\NodeFormTest\\:\\:testScheduledTransitions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/Functional/NodeFormTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\Functional\\\\NodeTranslationTest\\:\\:testTranslatedContent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/Functional/NodeTranslationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\Functional\\\\RoleAccessTest\\:\\:reviewPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/Functional/RoleAccessTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\Functional\\\\RoleAccessTest\\:\\:testUserAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/Functional/RoleAccessTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\FunctionalJavascript\\\\ReviewDateWidgetTest\\:\\:testReviewDatePublish\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/FunctionalJavascript/ReviewDateWidgetTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\FunctionalJavascript\\\\ReviewDateWidgetTest\\:\\:testReviewDateSummaryText\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/FunctionalJavascript/ReviewDateWidgetTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\Kernel\\\\ReviewDateEntityTest\\:\\:testActiveReviewDates\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/Kernel/ReviewDateEntityTest.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_review_date\\\\Kernel\\\\ReviewDateEntityTest\\:\\:testReviewDateEntities\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_review_date/tests/src/Kernel/ReviewDateEntityTest.php
+
+		-
+			message: "#^Function localgov_workflows_notifications_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/localgov_workflows_notifications.install
+
+		-
+			message: "#^Function localgov_workflows_notifications_update_10001\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/localgov_workflows_notifications.install
+
+		-
+			message: "#^Function localgov_workflows_notifications_update_10002\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/localgov_workflows_notifications.install
+
+		-
+			message: "#^Function localgov_workflows_notifications_entity_base_field_info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/localgov_workflows_notifications.module
+
+		-
+			message: "#^Function localgov_workflows_notifications_entity_operation_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/localgov_workflows_notifications.module
+
+		-
+			message: "#^Function localgov_workflows_notifications_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/localgov_workflows_notifications.module
+
+		-
+			message: "#^Function localgov_workflows_notifications_node_form_validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/localgov_workflows_notifications.module
+
+		-
+			message: "#^Function localgov_workflows_notifications_preprocess_field_multiple_value_form\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/localgov_workflows_notifications.module
 
@@ -261,46 +3136,281 @@ parameters:
 			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/src/Form/LocalgovServiceContactForm.php
 
 		-
+			message: "#^Method Drupal\\\\localgov_workflows_notifications\\\\Form\\\\LocalgovWorkflowsNotificationsSettingsForm\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
+
+		-
 			message: "#^Variable \\$queue_item might not be defined\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/src/WorkflowNotification.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows_notifications\\\\Functional\\\\ServiceContactCrudTest\\:\\:testServiceContactCrud\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/tests/src/Functional/ServiceContactCrudTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows_notifications\\\\Functional\\\\ServiceContactWidgetTest\\:\\:testAddServiceContacts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/tests/src/Functional/ServiceContactWidgetTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows_notifications\\\\Functional\\\\WorkflowNotificationSettingsTest\\:\\:testSettingsForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/tests/src/Functional/WorkflowNotificationSettingsTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows_notifications\\\\FunctionalJavascript\\\\ServiceContactFieldTest\\:\\:testAddServiceContactFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/tests/src/FunctionalJavascript/ServiceContactFieldTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows_notifications\\\\Kernel\\\\ReviewNotificationCronHookTest\\:\\:testEnqueueNodes\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/tests/src/Kernel/ReviewNotificationCronHookTest.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows_notifications\\\\Kernel\\\\ReviewNotificationEmailTest\\:\\:testEnqueueNodes\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/tests/src/Kernel/ReviewNotificationEmailTest.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows_notifications\\\\Kernel\\\\WorkflowNotificationTest\\:\\:testEnqueueNodes\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/modules/localgov_workflows_notifications/tests/src/Kernel/WorkflowNotificationTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$node of method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\WorkflowsAccessTest\\:\\:updateState\\(\\) expects Drupal\\\\node\\\\Entity\\\\Node, Drupal\\\\node\\\\NodeInterface given\\.$#"
-			count: 2
+			message: "#^Method Drupal\\\\localgov_workflows\\\\RequireLogMessage\\:\\:alterNodeTypeForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/src/RequireLogMessage.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_workflows\\\\RequireLogMessage\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/src/RequireLogMessage.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_workflows\\\\RequireLogMessage\\:\\:nodeTypeFormSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/src/RequireLogMessage.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_workflows\\\\RequireLogMessage\\:\\:setRequired\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/src/RequireLogMessage.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\ApprovalsDashboardTest\\:\\:testApprovalsDashboardLinks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/ApprovalsDashboardTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\ApprovalsDashboardTest\\:\\:testApprovalsDashboardView\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/ApprovalsDashboardTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\RequireLogTest\\:\\:testRequireLogContentType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/RequireLogTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\WorkflowsAccessTest\\:\\:createNodeWithState\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/modules/contrib/localgov_workflows/tests/src/Functional/WorkflowsAccessTest.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\WorkflowsAccessTest\\:\\:loginAs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/WorkflowsAccessTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\WorkflowsAccessTest\\:\\:testAuthorRole\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/WorkflowsAccessTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\WorkflowsAccessTest\\:\\:testContributorRole\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/WorkflowsAccessTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\WorkflowsAccessTest\\:\\:testEditorRole\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/WorkflowsAccessTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\WorkflowsAccessTest\\:\\:updateState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/WorkflowsAccessTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Functional\\\\WorkflowsTranslationTest\\:\\:testTranslatedContent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Functional/WorkflowsTranslationTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Kernel\\\\WorkflowsEnableTest\\:\\:testScheduledTransitions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/tests/src/Kernel/WorkflowsEnableTest.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Kernel\\\\WorkflowsInstallTest\\:\\:testEnableModule\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/tests/src/Kernel/WorkflowsInstallTest.php
 
 		-
-			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Kernel\\\\WorkflowsInstallTest\\:\\:testScheduledTransitionConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_workflows/tests/src/Kernel/WorkflowsInstallTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_workflows\\\\Kernel\\\\WorkflowsScheduledTransitionsTest\\:\\:testWorkflowsScheduledTransitions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/contrib/localgov_workflows/tests/src/Kernel/WorkflowsScheduledTransitionsTest.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 2
+			message: "#^Function localgov_install\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: web/profiles/contrib/localgov/localgov.install
+
+		-
+			message: "#^Function localgov_update_8201\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/localgov.install
+
+		-
+			message: "#^Function localgov_update_9501\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/localgov.install
+
+		-
+			message: "#^Function localgov_update_9502\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/localgov.install
+
+		-
+			message: "#^Function localgov_update_9503\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/localgov.install
+
+		-
+			message: "#^Function localgov_content_lock_install\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/modules/localgov_content_lock/localgov_content_lock.install
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_content_lock\\\\Functional\\\\ContentLockTest\\:\\:testContentLockConfiguration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/modules/localgov_content_lock/tests/src/Functional/ContentLockTest.php
+
+		-
+			message: "#^Function localgov_login_redirect_user_login\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/modules/localgov_login_redirect/localgov_login_redirect.module
+
+		-
+			message: "#^Method Drupal\\\\localgov_login_redirect\\\\Form\\\\LoginRedirectSettingsForm\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/modules/localgov_login_redirect/src/Form/LoginRedirectSettingsForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_login_redirect\\\\Form\\\\LoginRedirectSettingsForm\\:\\:submitForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/modules/localgov_login_redirect/src/Form/LoginRedirectSettingsForm.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_login_redirect\\\\Form\\\\LoginRedirectSettingsForm\\:\\:validateForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/modules/localgov_login_redirect/src/Form/LoginRedirectSettingsForm.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov_login_redirect\\\\Functional\\\\LoginRedirectTest\\:\\:testRedirectAtLogin\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/modules/localgov_login_redirect/tests/src/Functional/LoginRedirectTest.php
+
+		-
+			message: "#^Method Drupal\\\\localgov\\\\Plugin\\\\Block\\\\HomeWelcomeBlock\\:\\:blockSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/src/Plugin/Block/HomeWelcomeBlock.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov\\\\Functional\\\\LocalGovProfileTest\\:\\:testLocalGovDrupalProfile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/tests/src/Functional/LocalGovProfileTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\localgov\\\\Functional\\\\LocalGovUpdateTest\\:\\:setDatabaseDumpFiles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/profiles/contrib/localgov/tests/src/Functional/LocalGovUpdateTest.php
+
+		-
+			message: "#^Function localgov_base_form_preview_link_entity_form_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_form_system_theme_settings_alter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_preprocess_block\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_preprocess_container\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_preprocess_file_link\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_preprocess_guides_prev_next_block\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_preprocess_html\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_preprocess_node\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_preprocess_page\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Function localgov_base_views_pre_render\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/localgov_base.theme
+
+		-
+			message: "#^Method Drupal\\\\localgov_base_test_support\\\\Controller\\\\TestController\\:\\:testPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/modules/localgov_base_test_support/src/Controller/TestController.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_base_test_support\\\\EventSubscriber\\\\RenderTestBlockResponseSubscriber\\:\\:addRenderTestBlockHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/modules/localgov_base_test_support/src/EventSubscriber/RenderTestBlockResponseSubscriber.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\block_content\\\\Functional\\\\RegionRenderTest\\:\\:blockRegionProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/tests/Functional/RegionRenderTest.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\block_content\\\\Functional\\\\RegionRenderTest\\:\\:testRegionRender\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_base/tests/Functional/RegionRenderTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,6 +27,7 @@ parameters:
   ignoreErrors:
     - '#\Drupal calls should be avoided in classes, use dependency injection instead#'
     - '#Plugin definitions cannot be altered.#'
+    - identifier: missingType.iterableValue
     - '#Missing cache backend declaration for performance.#'
     - '#Plugin manager has cache backend specified but does not declare cache tags.#'
     # new static() is a best practice in Drupal, so we cannot fix that.
@@ -37,3 +38,7 @@ parameters:
     - '#Class Drupal\\localgov_forms\\Element\\AddressLookupElement extends deprecated class Drupal\\Core\\Render\\Element\\FormElement#'
     - '#Call to deprecated method renderPlain\(\)#'
     - '#Call to deprecated method rebuildThemeData\(\)#'
+
+rules:
+  - PHPStan\Rules\Functions\MissingFunctionReturnTypehintRule
+  - PHPStan\Rules\Methods\MissingMethodReturnTypehintRule


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This follows Drupal's latest coding standards/PHPStan changes to make return types required in all new methods and functions (see https://www.drupal.org/node/3461320). This applies to Core as well as contrib modules which run through the GitLab pipeline.

Since Drupal 9 it has been [recommended to add return types](https://www.drupal.org/docs/develop/standards/php/php-coding-standards#s-parameter-and-return-type-hinting), however it has not been enforced until now

> **Parameter and return type hinting**
> Beginning with Drupal 9, parameter and return type hints should be used wherever possible.

I've updated the PHPStan baseline so this will only apply to new code. I'll create separate tickets for updating existing code.