### PR TITLE
ci: update deprecated cache action and checkout action to latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
 
       - name: Clone drupal_container
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: localgovdrupal/drupal-container
           ref: php${{ matrix.php-version }}
@@ -169,7 +169,7 @@ jobs:
 
     steps:
       - name: Clone Drupal container
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: localgovdrupal/drupal-container
           ref: php${{ matrix.php-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         run: echo "COMPOSER_REF=dev-${GIT_BRANCH}" >> $GITHUB_ENV
 
       - name: Cached workspace
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./html
           key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Cached workspace
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./html
           key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Cached workspace
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./html
           key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
@@ -175,7 +175,7 @@ jobs:
           ref: php${{ matrix.php-version }}
 
       - name: Cached workspace
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./html
           key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Update the current deprecated cache action to a newer version (see https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/)

Also updates the checkout action for the same reason (https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)