### PR TITLE
Update ddev config to use PHP 8.3 by default.

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: localgov
 type: drupal10
 docroot: web
-php_version: "8.1"
+php_version: "8.3"
 webserver_type: nginx-fpm
 router_http_port: "80"
 router_https_port: "443"


### PR DESCRIPTION
Resolves #187 

Sets PHP to 8.3 in ddev default config.