### PR TITLE
Don't allow Composer plugin tbachert/spi to run by default 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,12 @@
         "allow-plugins": {
             "composer/installers": true,
             "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
+            "php-http/discovery": true,
             "phpstan/extension-installer": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "php-http/discovery": true
+            "tbachert/spi": false
         }
     },
     "extra": {


### PR DESCRIPTION
Fixes #191

## What does this change?

Explicitly deny the tbachert/spi Composer plugin.

## How to test

Run a `composer update` and don't see the message asking you whether you trust this plugin or now.