### PR TITLE
Update node version to what we use

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -16,7 +16,7 @@ mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: ""
 web_environment: []
-nodejs_version: "16"
+nodejs_version: "20"
 
 # Key features of ddev's config.yaml:
 

--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -51,7 +51,7 @@ services:
       command: '/bin/s6-svscan /etc/services.d'
     portforward: true
   node:
-    type: 'node:18'
+    type: 'node:20'
     globals:
       gulp-cli: latest
     overrides:


### PR DESCRIPTION
Closes 195

In LocalGov Base and other places, `.nvmrc` files use `20` for linting and things like that, so let's update ddev to use the same version.