### PR TITLE
[3.x] fix: ignore version in profile

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,6 +13,9 @@
   <exclude-pattern>web\/modules\/contrib\/(?!localgov_.*)</exclude-pattern>
   <exclude-pattern>web\/themes\/contrib\/(?!localgov_.*)</exclude-pattern>
 
+  <!-- Exclude profile version -->
+  <exclude-pattern>web/profiles/contrib/localgov/localgov.info.yml</exclude-pattern>
+
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
   <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Excludes the profile version file from linting. We need to set a version to prevent D11 erroring on the status page