### PR TITLE
fix: ignore localgov modules on drupal.org

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,6 +16,9 @@
   <!-- Exclude profile version -->
   <exclude-pattern>web/profiles/contrib/localgov/localgov.info.yml</exclude-pattern>
 
+  <!-- Exclude localgov modules that are on drupal.org -->
+  <exclude-pattern>web/profiles/contrib/localgov_utilities</exclude-pattern>
+
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
   <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,7 +17,7 @@
   <exclude-pattern>web/profiles/contrib/localgov/localgov.info.yml</exclude-pattern>
 
   <!-- Exclude localgov modules that are on drupal.org -->
-  <exclude-pattern>web/profiles/contrib/localgov_utilities</exclude-pattern>
+  <exclude-pattern>web/modules/contrib/localgov_utilities</exclude-pattern>
 
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
   <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This ignores localgov modules that are currently on drupal.org from failing coding standards checks due to having version numbers in the yaml file - see https://github.com/localgovdrupal/localgov_project/actions/runs/14486844490/job/40634110718

This should be fine as for this module we should be using GitLab on drupal.org for the phpcs checks