### PR TITLE
feat: upgrade spaze/phpstan-disallowed-calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.5",
-        "spaze/phpstan-disallowed-calls": "^3.4",
+        "spaze/phpstan-disallowed-calls": "^4.5.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "conflict": {


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Upgrades spaze/phpstan-disallowed-calls to 4.5.0+, the new version supports both PHPStan 1.x and 2.x