### PR TITLE
[3.2.x] fix: force drupal/facets 2.0 for dev dependencies and testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Obtain all dev dependencies for LocalGov Drupal
         run: |
+          composer --working-dir=./html require 'drupal/facets:^2.0'
           jq --raw-output '.packages[] | select(.name | startswith("localgovdrupal/")) | ."require-dev" | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/composer.lock | sort | uniq | xargs composer --working-dir=./html require --dev --no-interaction
 
   phpcs:


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This forces drupal/facets 2.0 on dev dependency installs for testing. This is due to drupal/facets_form not supporting facets 3.0, so will mean we cannot test facets 3.0 on the workflows.

Given facets_form low user base and the issue for supporting facets 3.0 hasn't been updated in 11 months, this might be better to be a submodule.