### PR TITLE
fix: ignore localgov_editoria11y from phpcs testing

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,6 +17,7 @@
   <exclude-pattern>web/profiles/contrib/localgov/localgov.info.yml</exclude-pattern>
 
   <!-- Exclude localgov modules that are on drupal.org -->
+  <exclude-pattern>web/modules/contrib/localgov_editoria11y</exclude-pattern>
   <exclude-pattern>web/modules/contrib/localgov_utilities</exclude-pattern>
 
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Like other drupal.org LocalGov Drupal modules, we should exclude localgov_editoria11y so it does not generate this error (https://github.com/localgovdrupal/localgov_project/actions/runs/18272941646/job/52018737553);

```bash
FILE: ...tml/web/modules/contrib/localgov_editoria11y/localgov_editoria11y.info.yml
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 1 LINE
--------------------------------------------------------------------------------
 1 | WARNING | Remove "project" from the info file, it will be added by
   |         | drupal.org packaging automatically
 1 | WARNING | Remove "datestamp" from the info file, it will be added by
   |         | drupal.org packaging automatically
 1 | WARNING | Remove "version" from the info file, it will be added by
   |         | drupal.org packaging automatically
--------------------------------------------------------------------------------
```