### PR TITLE
Serve Drupal from a /subdir to mimic drupal.org testing.

### DIFF
--- a/.ddev/config.selenium-standalone-chrome.yaml
+++ b/.ddev/config.selenium-standalone-chrome.yaml
@@ -2,14 +2,14 @@
 #
 web_environment:
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
-  - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
-  - SIMPLETEST_BASE_URL=http://web
+  - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}/subdir
+  - SIMPLETEST_BASE_URL=http://web/subdir
   - SIMPLETEST_DB=mysql://db:db@db/db
   # Use disable-dev-shm-usage instead of setting shm_usage
   # https://developers.google.com/web/tools/puppeteer/troubleshooting#tips
   # The format of chromeOptions is defined at https://chromedriver.chromium.org/capabilities
   - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"w3c\":false,\"goog:chromeOptions\":{\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]  # Nightwatch
-  - DRUPAL_TEST_BASE_URL=http://web
+  - DRUPAL_TEST_BASE_URL=http://web/subdir
   - DRUPAL_TEST_DB_URL=mysql://db:db@db/db
   - DRUPAL_TEST_WEBDRIVER_HOSTNAME=selenium-chrome
   - DRUPAL_TEST_WEBDRIVER_PORT=4444
@@ -20,5 +20,5 @@ web_environment:
   - DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES=node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
   - DRUPAL_NIGHTWATCH_OUTPUT=reports/nightwatch
   # DTT
-  - DTT_BASE_URL=http://web
+  - DTT_BASE_URL=http://web/subdir
   - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"w3c\":false,\"goog:chromeOptions\":{\"args\":[\"--disable-gpu\",\"--headless\", \"--no-sandbox\", \"--disable-dev-shm-usage\"]}}, \"http://selenium-chrome:4444/wd/hub\"]

--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -1,0 +1,107 @@
+# ddev drupal10 config
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
+
+
+# See https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
+
+server {
+    listen 80 default_server;
+    listen 443 ssl default_server;
+
+    root /var/www/html/web;
+
+    ssl_certificate /etc/ssl/certs/master.crt;
+    ssl_certificate_key /etc/ssl/certs/master.key;
+
+    include /etc/nginx/monitoring.conf;
+
+    index index.php index.htm index.html;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    location ~ /subdir/(.*) {
+        try_files /$1 @rewrite;
+    }
+
+    location @rewrite {
+        # For D7 and above:
+        # Clean URLs are handled in drupal_environment_initialize().
+        rewrite ^ /index.php;
+    }
+
+    # Handle image styles for Drupal 7+
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on socket
+    location ~ '\.php$|^/update.php' {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors off;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 10m;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
+    }
+
+    # Expire rules for static content
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    ## Regular private file serving (i.e. handled by Drupal).
+    location ^~ /system/files/ {
+        ## For not signaling a 404 in the error log whenever the
+        ## system/files directory is accessed add the line below.
+        ## Note that the 404 is the intended behavior.
+        log_not_found off;
+        access_log off;
+        expires 30d;
+        try_files $uri @rewrite;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
+    }
+
+    # js and css always loaded
+    location ~* \.(js|css)$ {
+        try_files $uri @rewrite;
+        expires -1;
+        log_not_found off;
+    }
+
+    include /etc/nginx/common.d/*.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}

--- a/assets/composer/settings.php
+++ b/assets/composer/settings.php
@@ -763,3 +763,10 @@ $ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
 if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
   require $ddev_settings;
 }
+
+// Rewrite SCRIPT_NAME to account for subdirectory install.
+if(isset($GLOBALS['request'])) {
+  $scriptName = $GLOBALS['request']->server->get('SCRIPT_NAME');
+  $scriptName = preg_match('#^/subdir/#', $scriptName) ? : "/subdir$scriptName";
+  $GLOBALS['request']->server->set('SCRIPT_NAME', $scriptName);
+}

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
                 "[web-root]/sites/default/settings.php": {
                     "mode": "replace",
                     "path": "assets/composer/settings.php",
-                    "overwrite": false
+                    "overwrite": true
                 },
                 "[web-root]/sites/default/settings.lando.php": {
                     "mode": "replace",

--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -1,0 +1,2 @@
+options:
+  uri: 'https://localgov.ddev.site/subdir'


### PR DESCRIPTION
Work in progress... 

The motivation here is to be able to run tests against the site installed under a dub-directory.

drupal.org does this, which is exposing issues in our tests and bugs in some places (eg. https://github.com/localgovdrupal/localgov_services/issues/335) 

It would be great to be able to run the tests locally to replicate this. 

The setup on this merge request serves the site at /subdir 

