### PR TITLE
fix: keep mariadb version for local dev in sync

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -10,7 +10,7 @@ additional_hostnames: []
 additional_fqdns: []
 database:
   type: mariadb
-  version: "10.3"
+  version: "10.6"
 nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true


### PR DESCRIPTION
This PR keeps the local version of MariaDB for DDEV in sync with what is already defined in the Lando file